### PR TITLE
STYLE: Change login page background to white

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -13,7 +13,7 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: #ffffff;
             min-height: 100vh;
             display: flex;
             align-items: center;
@@ -25,11 +25,12 @@
             background: #ffffff;
             padding: 48px;
             border-radius: 16px;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
             width: 100%;
             max-width: 450px;
             text-align: center;
             animation: slideUp 0.5s ease;
+            border: 1px solid #e9ecef;
         }
 
         @keyframes slideUp {
@@ -100,7 +101,7 @@
         .btn-login {
             width: 100%;
             padding: 16px 20px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: #4f46e5;
             color: white;
             border: none;
             border-radius: 8px;
@@ -108,12 +109,13 @@
             font-weight: 500;
             cursor: pointer;
             transition: all 0.2s ease;
-            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+            box-shadow: 0 2px 8px rgba(79, 70, 229, 0.3);
         }
 
         .btn-login:hover:not(:disabled) {
+            background: #4338ca;
             transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(102, 126, 234, 0.5);
+            box-shadow: 0 4px 12px rgba(79, 70, 229, 0.4);
         }
 
         .btn-login:active:not(:disabled) {


### PR DESCRIPTION
Changed the login page background from gradient (purple/blue) to white for a cleaner, more professional look:

- Background: Changed from linear-gradient to solid white (#ffffff)
- Container shadow: Reduced from heavy shadow to subtle elevation
- Added border: 1px solid border for better definition on white
- Button style: Changed from gradient to solid blue (#4f46e5)
- Button hover: Updated to match system color scheme

The login page now matches the overall clean aesthetic of the application while maintaining visual hierarchy and usability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)