### PR TITLE
FIX: Remove logs popup when loading revision from draft

### DIFF
--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -892,7 +892,7 @@ async function cargarDraftSeleccionado(draftId) {
     try {
         // Inicializar visor de logs para debugging en móvil
         limpiarLogs();
-        mostrarVisorLogs();
+        // mostrarVisorLogs(); // ELIMINADO: No mostrar popup de logs al cargar draft
 
         agregarLog('========================================', 'info');
         agregarLog(`Iniciando carga de draft: ${draftId}`, 'step');


### PR DESCRIPTION
- Commented out mostrarVisorLogs() call in cargarDraftSeleccionado()
- Logs are still captured but popup no longer appears
- Improves user experience when creating revisions from drafts