### PR TITLE
FEATURE: Implement intelligent Render keepalive system with business …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,47 @@ print(f'Supabase Storage: {\"OK\" if storage.storage_available else \"OFFLINE (f
 - **Platform**: Render.com
 - **Server**: Gunicorn (configured in `Procfile`)
 - **Python Version**: Specified in `runtime.txt`
+- **Keepalive**: ✅ **ACTIVE** - Intelligent business hours keepalive system (Sept 2025)
+
+### ⚡ Render Keepalive System (September 2025)
+
+**Automatic service keepalive to prevent Render free tier sleep (15-min idle timeout)**
+
+**Configuration:**
+- **Schedule**: Monday-Friday, 7:00 AM - 9:00 PM CST (Mexico City timezone)
+- **Frequency**: Every 10 minutes during business hours
+- **Monthly Usage**: ~300 hours/month (~40% of 750-hour free tier limit)
+- **Implementation**: APScheduler with CronTrigger + automated health checks
+
+**Key Features:**
+- ✅ **Smart Schedule**: Only active during CWS business hours (saves ~60% of compute hours)
+- ✅ **Zero Configuration**: Automatically activates in Render (disabled in local dev)
+- ✅ **Health Monitoring**: `/health` endpoint for automated pings and system status
+- ✅ **Admin Dashboard**: `/admin/keepalive/stats` for monitoring (requires authentication)
+- ✅ **Graceful Degradation**: Returns 200 even on errors to keep service awake
+- ✅ **Cost Efficient**: Maximizes free tier while maintaining business-hour availability
+
+**Technical Implementation:**
+- Module: `render_keepalive.py` - Background scheduler with business hours cron
+- Health Endpoint: `GET /health` - Public endpoint returning system status
+- Admin Stats: `GET /admin/keepalive/stats` - Authenticated statistics endpoint
+- Auto-activation: Detects Render environment and starts automatically
+- Logging: Detailed keepalive ping logs with success/failure tracking
+
+**Benefits:**
+- **Instant Response**: No 30-60 second cold start during business hours
+- **Better UX**: Users experience fast page loads throughout workday
+- **Resource Efficient**: Leaves 450+ hours/month for actual user traffic
+- **Predictable Performance**: Service ready when team needs it most
+
+**Monitoring:**
+```bash
+# Check keepalive status
+curl https://cotizador-cws.onrender.com/health
+
+# View detailed stats (requires login)
+curl https://cotizador-cws.onrender.com/admin/keepalive/stats
+```
 
 ### Deployment Process
 ```bash
@@ -433,6 +474,7 @@ cotizador_cws/
 ├── app.py                    # ENHANCED: Main Flask app with unified Supabase architecture
 ├── supabase_manager.py       # ENHANCED: Supabase PostgreSQL manager with offline fallback
 ├── pdf_manager.py            # ENHANCED: Unified PDF storage (Supabase Storage + Google Drive + Local)
+├── render_keepalive.py       # NEW: Intelligent keepalive for Render free tier (Sept 2025)
 ├── supabase_storage_manager.py # NEW: Supabase Storage integration
 ├── unified_storage_manager.py  # UPDATED: Unified storage operations with Supabase Storage
 ├── config.py                 # Environment-based configuration
@@ -466,6 +508,10 @@ cotizador_cws/
 - **Fallback Handling**: If CSV fails to load, system continues with empty materials list
 
 #### Hybrid System API Endpoints (NEW - August 2025)
+
+**Render Keepalive Management (NEW - September 2025):**
+- `GET /health` - Public health check endpoint (no auth required, for automated keepalive pings)
+- `GET /admin/keepalive/stats` - Get keepalive statistics and scheduler status (requires authentication)
 
 **Scheduler Management:**
 - `GET /admin/scheduler/estado` - Get scheduler status and next sync time

--- a/render_keepalive.py
+++ b/render_keepalive.py
@@ -1,0 +1,249 @@
+"""
+Render Keepalive System - Horario Laboral
+==========================================
+
+Sistema de keepalive inteligente para mantener el servicio de Render despierto
+durante horario laboral (Lunes-Viernes, 7am-9pm hora México/CST).
+
+Características:
+- Ping cada 10 minutos durante horario de oficina
+- Ahorra ~60% del límite de horas del plan gratuito
+- Consume solo ~300 horas/mes (~40% del límite de 750 horas)
+- APScheduler con CronTrigger para programación precisa
+
+Autor: Claude Code para CWS Company
+Fecha: Septiembre 2025
+"""
+
+import os
+import requests
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from datetime import datetime
+import logging
+
+# Configurar logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class RenderKeepalive:
+    """
+    Sistema de keepalive para Render con horario laboral.
+
+    Mantiene el servicio despierto únicamente durante horario de oficina:
+    - Lunes a Viernes
+    - 7:00 AM - 9:00 PM (CST/México)
+    - Ping cada 10 minutos
+    """
+
+    def __init__(self, app_url=None):
+        """
+        Inicializa el sistema de keepalive.
+
+        Args:
+            app_url: URL de la aplicación. Si es None, intenta detectarla automáticamente.
+        """
+        self.scheduler = BackgroundScheduler(timezone='America/Mexico_City')
+        self.app_url = app_url or self._detect_app_url()
+        self.health_endpoint = f"{self.app_url}/health"
+        self.ping_count = 0
+        self.last_ping = None
+        self.is_running = False
+
+        logger.info(f"[KEEPALIVE] Inicializado con URL: {self.app_url}")
+
+    def _detect_app_url(self):
+        """
+        Detecta automáticamente la URL de la aplicación.
+
+        Returns:
+            str: URL de la aplicación
+        """
+        # En Render, usar la URL de producción
+        if os.environ.get('RENDER'):
+            return "https://cotizador-cws.onrender.com"
+
+        # En desarrollo local, usar localhost
+        port = os.environ.get('PORT', '5000')
+        return f"http://localhost:{port}"
+
+    def ping(self):
+        """
+        Realiza un ping al endpoint /health para mantener el servicio despierto.
+        """
+        try:
+            response = requests.get(self.health_endpoint, timeout=10)
+            self.ping_count += 1
+            self.last_ping = datetime.now()
+
+            if response.status_code == 200:
+                logger.info(
+                    f"[KEEPALIVE] Ping #{self.ping_count} exitoso - "
+                    f"{self.last_ping.strftime('%Y-%m-%d %H:%M:%S')} - "
+                    f"Status: {response.status_code}"
+                )
+            else:
+                logger.warning(
+                    f"[KEEPALIVE] Ping #{self.ping_count} con status {response.status_code}"
+                )
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"[KEEPALIVE] Error en ping #{self.ping_count}: {str(e)}")
+
+    def start(self):
+        """
+        Inicia el scheduler de keepalive con horario laboral.
+
+        Configuración:
+        - Lunes a Viernes (day_of_week='mon-fri')
+        - 7:00 AM - 9:00 PM (hour='7-20')
+        - Cada 10 minutos (minute='*/10')
+        - Zona horaria: America/Mexico_City (CST)
+        """
+        if self.is_running:
+            logger.warning("[KEEPALIVE] El scheduler ya está en ejecución")
+            return
+
+        # Solo ejecutar en producción (Render)
+        if not os.environ.get('RENDER'):
+            logger.info("[KEEPALIVE] Modo desarrollo detectado - Keepalive desactivado")
+            return
+
+        try:
+            # Configurar cron: Lun-Vie, 7am-9pm, cada 10 min
+            trigger = CronTrigger(
+                day_of_week='mon-fri',  # Lunes a Viernes
+                hour='7-20',            # 7 AM a 8 PM (última ejecución a las 8:50 PM)
+                minute='*/10',          # Cada 10 minutos
+                timezone='America/Mexico_City'
+            )
+
+            self.scheduler.add_job(
+                self.ping,
+                trigger=trigger,
+                id='render_keepalive',
+                name='Render Keepalive - Horario Laboral',
+                max_instances=1,
+                replace_existing=True
+            )
+
+            self.scheduler.start()
+            self.is_running = True
+
+            logger.info("=" * 70)
+            logger.info("[KEEPALIVE] Sistema iniciado exitosamente")
+            logger.info("[KEEPALIVE] Horario: Lunes-Viernes, 7:00 AM - 9:00 PM CST")
+            logger.info("[KEEPALIVE] Frecuencia: Cada 10 minutos")
+            logger.info("[KEEPALIVE] Consumo estimado: ~300 horas/mes (~40% del límite)")
+            logger.info("=" * 70)
+
+            # Mostrar próximas ejecuciones
+            self._log_next_runs()
+
+        except Exception as e:
+            logger.error(f"[KEEPALIVE] Error al iniciar scheduler: {str(e)}")
+
+    def stop(self):
+        """
+        Detiene el scheduler de keepalive.
+        """
+        if not self.is_running:
+            logger.warning("[KEEPALIVE] El scheduler no está en ejecución")
+            return
+
+        try:
+            self.scheduler.shutdown(wait=False)
+            self.is_running = False
+            logger.info(f"[KEEPALIVE] Scheduler detenido - Total pings realizados: {self.ping_count}")
+        except Exception as e:
+            logger.error(f"[KEEPALIVE] Error al detener scheduler: {str(e)}")
+
+    def _log_next_runs(self, count=5):
+        """
+        Muestra las próximas ejecuciones programadas.
+
+        Args:
+            count: Número de ejecuciones futuras a mostrar
+        """
+        job = self.scheduler.get_job('render_keepalive')
+        if job:
+            logger.info(f"[KEEPALIVE] Próximas {count} ejecuciones:")
+            next_run = job.next_run_time
+            if next_run:
+                logger.info(f"  1. {next_run.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+
+    def get_stats(self):
+        """
+        Obtiene estadísticas del sistema de keepalive.
+
+        Returns:
+            dict: Estadísticas del sistema
+        """
+        job = self.scheduler.get_job('render_keepalive')
+        next_run = job.next_run_time if job else None
+
+        return {
+            'is_running': self.is_running,
+            'app_url': self.app_url,
+            'health_endpoint': self.health_endpoint,
+            'total_pings': self.ping_count,
+            'last_ping': self.last_ping.isoformat() if self.last_ping else None,
+            'next_run': next_run.isoformat() if next_run else None,
+            'schedule': 'Lunes-Viernes, 7:00 AM - 9:00 PM CST, cada 10 minutos',
+            'estimated_monthly_hours': '~300 horas (~40% del límite de 750 horas)'
+        }
+
+
+# Instancia global del keepalive
+_keepalive_instance = None
+
+
+def get_keepalive_instance():
+    """
+    Obtiene la instancia global del keepalive (patrón Singleton).
+
+    Returns:
+        RenderKeepalive: Instancia global del keepalive
+    """
+    global _keepalive_instance
+    if _keepalive_instance is None:
+        _keepalive_instance = RenderKeepalive()
+    return _keepalive_instance
+
+
+def init_keepalive(app_url=None):
+    """
+    Inicializa y arranca el sistema de keepalive.
+
+    Args:
+        app_url: URL de la aplicación (opcional)
+
+    Returns:
+        RenderKeepalive: Instancia del keepalive
+    """
+    keepalive = get_keepalive_instance()
+    if app_url and keepalive.app_url != app_url:
+        keepalive.app_url = app_url
+        keepalive.health_endpoint = f"{app_url}/health"
+
+    keepalive.start()
+    return keepalive
+
+
+if __name__ == '__main__':
+    # Test del sistema de keepalive
+    print("Iniciando test del sistema de keepalive...")
+    keepalive = RenderKeepalive()
+
+    print("\nEstadísticas iniciales:")
+    import json
+    print(json.dumps(keepalive.get_stats(), indent=2))
+
+    print("\nRealizando ping de prueba...")
+    keepalive.ping()
+
+    print("\nEstadísticas después del ping:")
+    print(json.dumps(keepalive.get_stats(), indent=2))
+
+    print("\n✅ Test completado")


### PR DESCRIPTION
…hours schedule

Adds automatic keepalive to prevent Render free tier sleep during business hours.

Key Features:
- Smart schedule: Mon-Fri, 7am-9pm CST (saves ~60% compute hours)
- Consumes ~300 hours/month (~40% of 750-hour free tier limit)
- Auto-activation in Render production (disabled in local dev)
- Health endpoint for automated pings
- Admin stats endpoint for monitoring

Implementation:
- New module: render_keepalive.py with APScheduler CronTrigger
- Health endpoint: GET /health (public, no auth)
- Admin endpoint: GET /admin/keepalive/stats (requires auth)
- Auto-initialization in app.py on startup
- Comprehensive documentation in CLAUDE.md

Benefits:
- Instant response during business hours (no cold start)
- Resource efficient - leaves 450+ hours for actual traffic
- Predictable performance when team needs it most
- Zero configuration required