### PR TITLE
ENHANCE: Mejorar prevención de drafts duplicados con limpieza backend

### DIFF
--- a/app.py
+++ b/app.py
@@ -1832,7 +1832,20 @@ def formulario():
                 
                 # ✅ LOG CRÍTICO: Cotización guardada exitosamente
                 logging.info(f"COTIZACION_GUARDADA: {numero_cotizacion} - Cliente: {datos.get('datosGenerales', {}).get('cliente', 'N/A')}")
-                
+
+                # ✅ ELIMINAR DRAFTS ASOCIADOS - Prevenir duplicados después de guardar
+                try:
+                    if numero_cotizacion:
+                        print(f"[DRAFT] Intentando eliminar drafts asociados a: {numero_cotizacion}")
+                        resultado_limpieza = db_manager.eliminar_drafts_por_numero_cotizacion(numero_cotizacion)
+                        if resultado_limpieza.get('success'):
+                            print(f"[DRAFT] ✅ {resultado_limpieza.get('mensaje')}")
+                        else:
+                            print(f"[DRAFT] ⚠️ No se pudieron eliminar drafts: {resultado_limpieza.get('error')}")
+                except Exception as draft_error:
+                    print(f"[DRAFT] ❌ Error limpiando drafts (no crítico): {draft_error}")
+                    # No bloquear el guardado por errores en drafts
+
                 # Verificar si es un fallo silencioso detectado
                 if resultado.get("tipo_error") == "fallo_silencioso":
                     critical_logger = logging.getLogger('FALLOS_CRITICOS')

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -3389,6 +3389,7 @@ async function guardarCotizacion() {
 
             // ✅ MARCAR COTIZACIÓN COMO COMPLETADA - Prevenir creación de nuevos drafts
             cotizacionCompletada = true;
+            formModificado = false; // Resetear para prevenir beforeunload
             console.log('[DRAFT] Cotización marcada como completada - auto-guardado deshabilitado');
 
             // ✅ DETENER TIMER DE AUTO-GUARDADO


### PR DESCRIPTION
Mejoras adicionales sobre commit anterior:
- ✅ Agregar formModificado = false al guardar para prevenir beforeunload
- ✅ Nueva función: eliminar_drafts_por_numero_cotizacion() en supabase_manager
- ✅ Limpiar drafts desde backend al guardar cotización exitosa
- ✅ Eliminar drafts de Supabase Y JSON local por número de cotización

Problema adicional identificado:
- El evento beforeunload podía crear nuevos drafts al navegar
- Podían quedar drafts huérfanos con el mismo número de cotización
- La limpieza solo por draftId no era suficiente

Solución implementada:
Backend (supabase_manager.py):
- Nueva función eliminar_drafts_por_numero_cotizacion()
- Busca drafts por numero en datosGenerales
- Elimina de Supabase y JSON local
- Retorna cantidad de drafts eliminados

Backend (app.py):
- Llamar a eliminar_drafts_por_numero_cotizacion() después de guardar
- Logging completo del proceso de limpieza
- No bloquear guardado si limpieza falla

Frontend (formulario.html):
- Resetear formModificado = false al guardar
- Prevenir guardado en beforeunload

Resultado esperado:
- Limpieza completa de drafts al guardar cotización
- No más drafts duplicados o huérfanos
- Sistema robusto contra casos edge