### PR TITLE
feat: add approximate weight note per item in quotation form

### DIFF
--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -851,6 +851,7 @@ function recopilarItems() {
             if (material && material.trim() !== "") {
                 const materialData = {
                     material: material,
+                    peso: row.querySelector('.peso-input')?.value || '',
                     cantidad: row.querySelector('.cantidad-input')?.value || '',
                     unidad: row.querySelector('.unidad-select')?.value || 'metros',  // FIXED: Capturar unidad
                     precio: row.querySelector('.precio-input')?.value || '',
@@ -2541,6 +2542,10 @@ function crearTemplateItem(numero) {
                 </button>
             </div>
 
+            <div class="peso-aproximado-display text-xs text-gray-400 italic text-right mt-1" style="display:none;">
+                Peso aproximado: <span class="peso-aproximado-valor">0.00</span> kg
+            </div>
+
             <div class="border-t pt-4">
                 <h3 class="text-lg font-semibold text-blue-600 mb-3">Otros Materiales</h3>
                 <div class="otros-materiales-container space-y-2">
@@ -2711,6 +2716,7 @@ function eliminarFila(button, tipo) {
     const itemElement = button.closest('.item-block');
     if (fila) fila.remove();
     if (itemElement) {
+        if (tipo === 'material') calcularPesoAproximadoItem(itemElement);
         setTimeout(() => {
             calcularCostosItem(itemElement);
             actualizarTodosLosCalculos();
@@ -2839,6 +2845,7 @@ function calcularSubtotalMaterial(input) {
     // Recalcular totales del item
     const itemElement = row.closest('.item-block');
     if (itemElement) {
+        calcularPesoAproximadoItem(itemElement);
         setTimeout(() => {
             calcularCostosItem(itemElement);
             actualizarTodosLosCalculos();
@@ -2909,6 +2916,9 @@ function toggleCotizarPorPeso(materialRow, mostrarCamposPeso) {
             input.value = '';
         });
     }
+
+    const itemBlock = materialRow.closest('.item-block');
+    if (itemBlock) calcularPesoAproximadoItem(itemBlock);
 }
 
 // Función auxiliar para detectar si es cotización por peso
@@ -2954,10 +2964,48 @@ function calcularSubtotalPeso(input) {
     // Recalcular totales del item
     const itemElement = row.closest('.item-block');
     if (itemElement) {
+        calcularPesoAproximadoItem(itemElement);
         setTimeout(() => {
             calcularCostosItem(itemElement);
             actualizarTodosLosCalculos();
         }, 10);
+    }
+}
+
+function calcularPesoAproximadoItem(itemBlock) {
+    if (!itemBlock) return;
+    let pesoTotal = 0;
+
+    itemBlock.querySelectorAll('.materiales-container .material-row').forEach(row => {
+        const camposPeso = row.querySelector('.material-campos-peso');
+        const modoPeso = camposPeso && camposPeso.style.display !== 'none';
+
+        if (modoPeso) {
+            const pesoEstructura = parseFloat(row.querySelector('.peso-estructura-input')?.value || 0);
+            if (!isNaN(pesoEstructura)) pesoTotal += pesoEstructura;
+        } else {
+            const pesoInput = row.querySelector('.peso-input');
+            const cantidadInput = row.querySelector('.cantidad-input');
+            const unidadSelect = row.querySelector('.unidad-select');
+            const materialSelect = row.querySelector('.material-select');
+            const peso = parseFloat(pesoInput?.value || 0);
+            const cantidadOriginal = parseFloat(cantidadInput?.value || 0);
+            if (!isNaN(peso) && peso > 0 && !isNaN(cantidadOriginal) && cantidadOriginal > 0) {
+                const cantidadConvertida = (unidadSelect && materialSelect)
+                    ? aplicarConversionUnidad(cantidadOriginal, unidadSelect.value, materialSelect)
+                    : cantidadOriginal;
+                pesoTotal += peso * cantidadConvertida;
+            }
+        }
+    });
+
+    const display = itemBlock.querySelector('.peso-aproximado-display');
+    if (!display) return;
+    if (pesoTotal > 0) {
+        display.querySelector('.peso-aproximado-valor').textContent = pesoTotal.toFixed(2);
+        display.style.display = '';
+    } else {
+        display.style.display = 'none';
     }
 }
 

--- a/templates/ver_cotizacion.html
+++ b/templates/ver_cotizacion.html
@@ -411,6 +411,19 @@
                         </tbody>
                     </table>
                 </div>
+                {% set factores = {'metros': 1, 'centimetros': 0.01, 'pulgadas': 0.0254, 'metros_cuadrados': 1, 'centimetros_cuadrados': 0.0001, 'pulgadas_cuadradas': 0.00064516} %}
+                {% set peso_ns = namespace(total=0) %}
+                {% for material in item.get('materiales', []) %}
+                    {% if material.get('material') == 'COTIZAR_POR_PESO' %}
+                        {% set peso_ns.total = peso_ns.total + (material.get('pesoEstructura', 0) | float) %}
+                    {% else %}
+                        {% set factor = factores.get(material.get('unidad', 'metros'), 1) %}
+                        {% set peso_ns.total = peso_ns.total + ((material.get('peso', 0) | float) * (material.get('cantidad', 0) | float) * factor) %}
+                    {% endif %}
+                {% endfor %}
+                {% if peso_ns.total > 0 %}
+                <p style="font-size: 11px; color: #9ca3af; text-align: right; margin: 4px 0 0 0; font-style: italic;">Peso aproximado: {{ "%.2f" | format(peso_ns.total) }} kg</p>
+                {% endif %}
                 {% endif %}
 
                 <!-- Otros Materiales del Item -->


### PR DESCRIPTION
Adds a discrete real-time "Peso aproximado" display before the Otros
Materiales section in the quotation form. The weight is calculated from
regular materials (kg/m from CSV × converted quantity) and from
COTIZAR_POR_PESO rows (direct structure weight). Updates automatically
when materials, quantities or units change or rows are added/removed.

Also stores the material's peso field in recopilarItems() and shows the
same reference note in the ver_cotizacion detail screen using Jinja2.

https://claude.ai/code/session_018nyYFGHuj4zZdmNjfi3HgX