### PR TITLE
feat: add download button to quotation list actions

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -618,6 +618,7 @@
                         <td>
                             <div class="acciones-col">
                                 <a href="/pdf/{{ cot.numero }}" target="_blank" class="btn-icon">PDF</a>
+                                <a href="/pdf/{{ cot.numero }}" download="{{ cot.numero }}.pdf" class="btn-icon">Descargar</a>
                                 {% if cot.tiene_desglose %}
                                 <a href="/desglose/{{ cot.numero }}" class="btn-icon">Desglose</a>
                                 {% else %}


### PR DESCRIPTION
Adds a "Descargar" button next to the PDF button in the quotations table,
using the same btn-icon style. Uses the download attribute to trigger a
direct PDF file download with the quotation number as filename.

https://claude.ai/code/session_015pqn4xe8WnXzdNszqdWrLw