### PR TITLE
feat: smart download button uses Web Share API on iOS, download on de…

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -618,7 +618,7 @@
                         <td>
                             <div class="acciones-col">
                                 <a href="/pdf/{{ cot.numero }}" target="_blank" class="btn-icon">PDF</a>
-                                <a href="/pdf/{{ cot.numero }}" download="{{ cot.numero }}.pdf" class="btn-icon">Descargar</a>
+                                <button class="btn-icon" onclick="descargarOCompartirPDF('{{ cot.numero }}')">Descargar</button>
                                 {% if cot.tiene_desglose %}
                                 <a href="/desglose/{{ cot.numero }}" class="btn-icon">Desglose</a>
                                 {% else %}
@@ -848,6 +848,21 @@
         document.getElementById('modalDrafts').addEventListener('click', function(e) {
             if (e.target === this) cerrarModalDrafts();
         });
+
+        function descargarOCompartirPDF(numero) {
+            const url = `/pdf/${numero}`;
+            if (navigator.share) {
+                navigator.share({ url: window.location.origin + url })
+                    .catch(() => {});
+            } else {
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `${numero}.pdf`;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+            }
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
…sktop

On iPhone/mobile shows the native share sheet (share, save to Files, AirDrop, etc.) via navigator.share. Falls back to direct file download on desktop browsers that don't support the Web Share API.

https://claude.ai/code/session_015pqn4xe8WnXzdNszqdWrLw