### PR TITLE
feat: agregar modo de edición menor sin nueva revisión

### DIFF
--- a/app.py
+++ b/app.py
@@ -2013,6 +2013,21 @@ def formulario():
                 "detalle": str(e)
             }), 500
     
+    # Verificar si es edición menor (corrección sin nueva revisión)
+    edicion_menor_id = request.args.get('edicion_menor')
+    modo_edicion_menor = False
+    datos_edicion_menor = None
+
+    if edicion_menor_id:
+        print(f"[EDICION_MENOR] Cargando formulario para edición menor: '{edicion_menor_id}'")
+        resultado_em = db_manager.obtener_cotizacion(edicion_menor_id)
+        if resultado_em.get('encontrado'):
+            datos_edicion_menor = resultado_em['item']
+            modo_edicion_menor = True
+            print(f"[EDICION_MENOR] Cotización cargada para edición menor: {edicion_menor_id}")
+        else:
+            print(f"[EDICION_MENOR] Cotización no encontrada: '{edicion_menor_id}'")
+
     # Verificar si es una nueva revisión
     revision_id = request.args.get('revision')
     datos_precargados = None
@@ -2055,7 +2070,9 @@ def formulario():
                          materiales=LISTA_MATERIALES,
                          datos_precargados=datos_precargados,
                          info_bloqueo_revision=info_bloqueo_revision,
-                         vendedor_sesion=session.get('vendedor', ''))
+                         vendedor_sesion=session.get('vendedor', ''),
+                         modo_edicion_menor=modo_edicion_menor,
+                         datos_edicion_menor=datos_edicion_menor)
 
 @app.route("/debug-materiales")
 def debug_materiales():
@@ -2254,6 +2271,41 @@ def eliminar_draft(draft_id):
         error_msg = str(e)
         print(f"[API] Excepción eliminando draft: {error_msg}")
         return jsonify({"success": False, "error": error_msg}), 500
+
+# ========================================
+# EDICIÓN MENOR (sin nueva revisión)
+# ========================================
+
+@app.route("/api/cotizacion/<path:numero_cotizacion>/edicion-menor", methods=["PATCH"])
+def edicion_menor(numero_cotizacion):
+    """
+    Corrige campos de texto (typos, ortografía) sin generar nueva revisión.
+    Solo acepta: datosGenerales.atencionA/contacto,
+                 condiciones.tiempoEntrega/entregaEn/comentarios,
+                 items[].descripcion/notas
+    """
+    try:
+        parche = request.get_json()
+        if not parche:
+            return jsonify({"success": False, "error": "No se recibieron datos"}), 400
+
+        usuario = session.get('vendedor', 'desconocido')
+        resultado = db_manager.edicion_menor_cotizacion(numero_cotizacion, parche, usuario)
+
+        if resultado.get('success'):
+            print(f"[EDICION_MENOR] Corrección guardada: {numero_cotizacion}")
+            return jsonify({
+                "success": True,
+                "numero_cotizacion": numero_cotizacion,
+                "mensaje": "Corrección guardada correctamente"
+            }), 200
+        else:
+            return jsonify(resultado), 400
+
+    except Exception as e:
+        print(f"[EDICION_MENOR] Error: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
 
 @app.route("/diagnostico-completo")
 def diagnostico_completo():

--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -1983,6 +1983,112 @@ class SupabaseManager:
         
         return cot_limpia
     
+    # ──────────────────────────────────────────────────────────
+    # EDICIÓN MENOR (sin nueva revisión)
+    # ──────────────────────────────────────────────────────────
+
+    # Campos que se pueden corregir sin generar revisión
+    CAMPOS_EDICION_MENOR = {
+        'datosGenerales': {'atencionA', 'contacto'},
+        'condiciones': {'tiempoEntrega', 'entregaEn', 'comentarios'},
+        'items': {'descripcion', 'notas'},
+    }
+
+    def validar_campos_edicion_menor(self, parche: dict) -> tuple:
+        """
+        Verifica que el parche solo contenga campos de la whitelist.
+        Retorna (True, '') si es válido, (False, mensaje) si no.
+        """
+        dg = parche.get('datosGenerales', {})
+        prohibidos_dg = set(dg.keys()) - self.CAMPOS_EDICION_MENOR['datosGenerales']
+        if prohibidos_dg:
+            return False, f"Campos no permitidos en datosGenerales: {prohibidos_dg}"
+
+        cond = parche.get('condiciones', {})
+        prohibidos_cond = set(cond.keys()) - self.CAMPOS_EDICION_MENOR['condiciones']
+        if prohibidos_cond:
+            return False, f"Campos no permitidos en condiciones: {prohibidos_cond}"
+
+        for i, item in enumerate(parche.get('items', [])):
+            prohibidos_item = set(item.keys()) - self.CAMPOS_EDICION_MENOR['items']
+            if prohibidos_item:
+                return False, f"Campos no permitidos en ítem {i}: {prohibidos_item}"
+
+        return True, ''
+
+    def edicion_menor_cotizacion(self, numero_cotizacion: str, parche: dict, usuario: str = '') -> dict:
+        """
+        Aplica correcciones de texto (typos, ortografía) sin generar nueva revisión.
+        Solo modifica los campos de CAMPOS_EDICION_MENOR; todo lo demás permanece intacto.
+        """
+        try:
+            # 1. Validar whitelist
+            valido, mensaje_error = self.validar_campos_edicion_menor(parche)
+            if not valido:
+                return {'success': False, 'error': mensaje_error}
+
+            # 2. Obtener cotización actual
+            resultado = self.obtener_cotizacion(numero_cotizacion)
+            if not resultado.get('encontrado'):
+                return {'success': False, 'error': f'Cotización no encontrada: {numero_cotizacion}'}
+
+            cotizacion = resultado['item']
+
+            # 3. Aplicar parche solo en campos blanqueados
+            campos_modificados = []
+
+            dg_patch = parche.get('datosGenerales', {})
+            for campo in self.CAMPOS_EDICION_MENOR['datosGenerales']:
+                if campo in dg_patch:
+                    cotizacion['datosGenerales'][campo] = dg_patch[campo]
+                    campos_modificados.append(f'datosGenerales.{campo}')
+
+            cond_patch = parche.get('condiciones', {})
+            if 'condiciones' not in cotizacion or not isinstance(cotizacion.get('condiciones'), dict):
+                cotizacion['condiciones'] = {}
+            for campo in self.CAMPOS_EDICION_MENOR['condiciones']:
+                if campo in cond_patch:
+                    cotizacion['condiciones'][campo] = cond_patch[campo]
+                    campos_modificados.append(f'condiciones.{campo}')
+
+            items_patch = parche.get('items', [])
+            for i, item_patch in enumerate(items_patch):
+                if i < len(cotizacion.get('items', [])):
+                    for campo in self.CAMPOS_EDICION_MENOR['items']:
+                        if campo in item_patch:
+                            cotizacion['items'][i][campo] = item_patch[campo]
+                            campos_modificados.append(f'items[{i}].{campo}')
+
+            if not campos_modificados:
+                return {'success': False, 'error': 'No se enviaron campos editables'}
+
+            # 4. Registrar auditoría en observaciones
+            import json as _json
+            obs_raw = cotizacion.get('observaciones') or '{}'
+            try:
+                obs = _json.loads(obs_raw) if isinstance(obs_raw, str) else (obs_raw or {})
+            except Exception:
+                obs = {}
+            if not isinstance(obs, dict):
+                obs = {}
+            historial = obs.get('ediciones_menores', [])
+            historial.append({
+                'timestamp': datetime.now().isoformat(),
+                'usuario': usuario,
+                'campos_modificados': campos_modificados,
+            })
+            obs['ediciones_menores'] = historial
+            cotizacion['observaciones'] = _json.dumps(obs, ensure_ascii=False)
+
+            # 5. Guardar (reutiliza toda la lógica de fallback existente)
+            print(f"[EDICION_MENOR] Guardando correcciones en: {numero_cotizacion} | campos: {campos_modificados}")
+            return self.guardar_cotizacion(cotizacion)
+
+        except Exception as e:
+            error_msg = safe_str(e)
+            print(f"[EDICION_MENOR] Error: {error_msg}")
+            return {'success': False, 'error': error_msg}
+
     def obtener_estado_sincronizacion(self):
         """Obtiene información del estado de sincronización"""
         try:

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -454,10 +454,26 @@
             </div>
         </section>
 
+        <!-- BANNER MODO EDICIÓN MENOR -->
+        <div id="banner-edicion-menor" style="display:none; background:#fef3c7; border:2px solid #f59e0b; border-radius:8px; padding:14px 20px; margin-bottom:16px;">
+            <div style="display:flex; align-items:flex-start; gap:12px;">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="#f59e0b" style="flex-shrink:0; margin-top:2px;">
+                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
+                </svg>
+                <div>
+                    <strong style="color:#92400e;">Modo Edición Menor</strong>
+                    <p style="margin:4px 0 0; color:#78350f; font-size:14px;">
+                        Solo puedes corregir texto: nombre de contacto, correo/teléfono, descripción de ítems, tiempo de entrega, lugar de entrega y comentarios.
+                        Los campos en gris no son editables. Para cambios en precios o condiciones comerciales usa <strong>Nueva Revisión</strong>.
+                    </p>
+                </div>
+            </div>
+        </div>
+
         <!-- BOTONES DE ACCIÓN -->
         <section class="bg-white rounded-lg shadow-lg p-6">
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                <button type="button" id="btn-guardar" onclick="guardarCotizacion()" 
+                <button type="button" id="btn-guardar" onclick="guardarCotizacion()"
                         class="icon-btn primary flex items-center gap-2 px-6 py-3 w-auto h-auto rounded-lg font-medium transition-all duration-200">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"/>
@@ -501,6 +517,10 @@ const DATOS_PRECARGADOS = {{ datos_precargados | tojson if datos_precargados els
 
 // Información de bloqueo de revisión (si intenta crear revisión desde versión antigua)
 const INFO_BLOQUEO_REVISION = {{ info_bloqueo_revision | tojson if info_bloqueo_revision else 'null' }};
+
+// Modo edición menor (corrección de typos sin nueva revisión)
+const MODO_EDICION_MENOR = {{ modo_edicion_menor | tojson if modo_edicion_menor is defined else 'false' }};
+const DATOS_EDICION_MENOR = {{ datos_edicion_menor | tojson if datos_edicion_menor is defined and datos_edicion_menor else 'null' }};
 
 // Función para generar opciones de materiales
 function generarOpcionesMateriales() {
@@ -1190,12 +1210,19 @@ document.addEventListener('DOMContentLoaded', function() {
         console.log('Campo numeroCotizacion configurado como disabled sin required');
     }
 
-    // Cargar datos precargados si existen
+    // Cargar datos precargados si existen (revisión) o edición menor
     if (DATOS_PRECARGADOS) {
         cargarDatosPrecargados();
+    } else if (MODO_EDICION_MENOR && DATOS_EDICION_MENOR) {
+        cargarDatosEdicionMenor();
     }
     setTimeout(() => { agregarItem(); }, 500);
     configurarEventListeners();
+
+    // Activar modo edición menor si corresponde
+    if (MODO_EDICION_MENOR) {
+        setTimeout(() => activarModoEdicionMenor(), 800);
+    }
 
     // Inicializar modal de revisión si es necesario
     inicializarModalRevision();
@@ -1678,6 +1705,52 @@ function configurarEventListeners() {
             }
         }
     });
+}
+
+function cargarDatosEdicionMenor() {
+    if (!DATOS_EDICION_MENOR) return;
+    try {
+        const dg = DATOS_EDICION_MENOR.datosGenerales || {};
+        const cond = DATOS_EDICION_MENOR.condiciones || {};
+
+        // Campos editables de datosGenerales
+        ['vendedor', 'proyecto', 'cliente', 'atencionA', 'contacto', 'revision', 'fecha'].forEach(campo => {
+            const el = document.querySelector(`[name="${campo}"]`);
+            if (el && dg[campo] !== undefined) el.value = dg[campo];
+        });
+
+        // Número de cotización (siempre readonly)
+        const campoNum = document.querySelector('[name="numeroCotizacion"]');
+        if (campoNum) campoNum.value = DATOS_EDICION_MENOR.numeroCotizacion || '';
+        const campoHidden = document.querySelector('[name="numeroCotizacionHidden"]');
+        if (campoHidden) campoHidden.value = DATOS_EDICION_MENOR.numeroCotizacion || '';
+
+        // Condiciones
+        ['moneda', 'tipoCambio', 'tiempoEntrega', 'entregaEn', 'terminos', 'comentarios'].forEach(campo => {
+            const el = document.querySelector(`[name="${campo}"]`);
+            if (el && cond[campo] !== undefined) el.value = cond[campo];
+        });
+
+        // Items: se cargan en el timeout de activarModoEdicionMenor vía agregarItem
+        // Aquí precargamos las descripciones después de que se agreguen los items
+        if (DATOS_EDICION_MENOR.items && DATOS_EDICION_MENOR.items.length > 0) {
+            setTimeout(() => {
+                const bloques = document.querySelectorAll('.item-block');
+                DATOS_EDICION_MENOR.items.forEach((item, i) => {
+                    if (i < bloques.length) {
+                        const desc = bloques[i].querySelector('.descripcion-item');
+                        if (desc && item.descripcion) desc.value = item.descripcion;
+                        const notas = bloques[i].querySelector('[name="notas[]"]');
+                        if (notas && item.notas) notas.value = item.notas;
+                    }
+                });
+            }, 1200);
+        }
+
+        console.log('[EDICION_MENOR] Datos cargados:', DATOS_EDICION_MENOR.numeroCotizacion);
+    } catch (e) {
+        console.error('[EDICION_MENOR] Error cargando datos:', e);
+    }
 }
 
 function cargarDatosPrecargados() {
@@ -3529,6 +3602,146 @@ async function guardarCotizacion() {
             btnGuardar.classList.remove('btn-loading');
             btnGuardar.innerHTML = textoOriginal;
         }
+    }
+}
+
+// ============================================================
+// MODO EDICIÓN MENOR
+// ============================================================
+
+function activarModoEdicionMenor() {
+    if (!MODO_EDICION_MENOR || !DATOS_EDICION_MENOR) return;
+
+    // Mostrar banner
+    const banner = document.getElementById('banner-edicion-menor');
+    if (banner) banner.style.display = 'block';
+
+    // Cambiar botón guardar
+    const btnGuardar = document.getElementById('btn-guardar');
+    if (btnGuardar) {
+        btnGuardar.onclick = guardarEdicionMenor;
+        btnGuardar.innerHTML = `<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg> Guardar Corrección`;
+        btnGuardar.style.backgroundColor = '#f59e0b';
+        btnGuardar.style.borderColor = '#f59e0b';
+        btnGuardar.style.color = 'white';
+    }
+
+    // Deshabilitar campos NO editables
+    // Todos los campos de datosGenerales excepto atencionA y contacto
+    ['vendedor', 'proyecto', 'cliente', 'revision', 'fecha'].forEach(campo => {
+        const el = document.querySelector(`[name="${campo}"]`);
+        if (el) {
+            el.setAttribute('disabled', 'disabled');
+            el.style.backgroundColor = '#f3f4f6';
+            el.style.cursor = 'not-allowed';
+        }
+    });
+
+    // Deshabilitar la sección de condiciones financieras (moneda, tipoCambio, terminos)
+    ['moneda', 'tipoCambio', 'terminos'].forEach(campo => {
+        const el = document.querySelector(`[name="${campo}"]`);
+        if (el) {
+            el.setAttribute('disabled', 'disabled');
+            el.style.backgroundColor = '#f3f4f6';
+            el.style.cursor = 'not-allowed';
+        }
+    });
+
+    // En los items: deshabilitar todo excepto descripcion y notas
+    setTimeout(() => {
+        document.querySelectorAll('.item-block').forEach(bloque => {
+            bloque.querySelectorAll('input, select, textarea').forEach(el => {
+                const nombre = el.name || el.className || '';
+                const esEditable = el.classList.contains('descripcion-item') ||
+                                   (el.name && el.name === 'notas[]');
+                if (!esEditable) {
+                    el.setAttribute('disabled', 'disabled');
+                    el.style.backgroundColor = '#f3f4f6';
+                    el.style.cursor = 'not-allowed';
+                }
+            });
+            // Ocultar botones de agregar/eliminar materiales e ítems
+            bloque.querySelectorAll('.btn-eliminar-item, .btn-agregar-material, .btn-eliminar-material, .btn-agregar-otro, .btn-eliminar-otro').forEach(btn => {
+                btn.style.display = 'none';
+            });
+        });
+        // Ocultar botón agregar ítem
+        const btnAgregarItem = document.getElementById('btn-agregar-item') || document.querySelector('[onclick*="agregarItem"]');
+        if (btnAgregarItem) btnAgregarItem.style.display = 'none';
+    }, 600);
+
+    // Deshabilitar botón limpiar / PDF para no confundir
+    const btnGenerar = document.getElementById('btn-generar');
+    if (btnGenerar) btnGenerar.style.display = 'none';
+
+    console.log('[EDICION_MENOR] Modo activado para:', DATOS_EDICION_MENOR.numeroCotizacion);
+}
+
+async function guardarEdicionMenor() {
+    const btnGuardar = document.getElementById('btn-guardar');
+    const textoOriginal = btnGuardar.innerHTML;
+    btnGuardar.disabled = true;
+    btnGuardar.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 6v3l4-4-4-4v3c-4.42 0-8 3.58-8 8 0 1.57.46 3.03 1.24 4.26L6.7 14.8c-.45-.83-.7-1.79-.7-2.8 0-3.31 2.69-6 6-6zm6.76 1.74L17.3 9.2c.44.84.7 1.79.7 2.8 0 3.31-2.69 6-6 6v-3l-4 4 4 4v-3c4.42 0 8-3.58 8-8 0-1.57-.46-3.03-1.24-4.26z"/></svg> Guardando...';
+
+    try {
+        const numero = DATOS_EDICION_MENOR.numeroCotizacion;
+
+        // Recopilar solo campos editables
+        const parche = { datosGenerales: {}, condiciones: {}, items: [] };
+
+        const atencionA = document.querySelector('[name="atencionA"]');
+        if (atencionA) parche.datosGenerales.atencionA = atencionA.value.trim();
+
+        const contacto = document.querySelector('[name="contacto"]');
+        if (contacto) parche.datosGenerales.contacto = contacto.value.trim();
+
+        const tiempoEntrega = document.querySelector('[name="tiempoEntrega"]');
+        if (tiempoEntrega) parche.condiciones.tiempoEntrega = tiempoEntrega.value.trim();
+
+        const entregaEn = document.querySelector('[name="entregaEn"]');
+        if (entregaEn) parche.condiciones.entregaEn = entregaEn.value.trim();
+
+        const comentarios = document.querySelector('[name="comentarios"]');
+        if (comentarios) parche.condiciones.comentarios = comentarios.value.trim();
+
+        document.querySelectorAll('.item-block').forEach((bloque, i) => {
+            const desc = bloque.querySelector('.descripcion-item');
+            const notas = bloque.querySelector('[name="notas[]"]');
+            parche.items.push({
+                descripcion: desc ? desc.value.trim() : '',
+                notas: notas ? notas.value.trim() : ''
+            });
+        });
+
+        const respuesta = await fetch(`/api/cotizacion/${encodeURIComponent(numero)}/edicion-menor`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(parche)
+        });
+
+        const resultado = await respuesta.json();
+
+        if (resultado.success) {
+            btnGuardar.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z"/></svg> Corrección guardada';
+            btnGuardar.style.backgroundColor = '#10b981';
+            btnGuardar.style.borderColor = '#10b981';
+            alert(`¡Corrección guardada exitosamente!\n\nNúmero: ${numero}\n\nEl PDF se regenerará con los cambios.`);
+            // Regenerar PDF en segundo plano
+            fetch('/generar_pdf', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ numeroCotizacion: numero })
+            }).catch(() => {});
+        } else {
+            alert(`Error al guardar la corrección:\n\n${resultado.error}`);
+            btnGuardar.disabled = false;
+            btnGuardar.innerHTML = textoOriginal;
+        }
+
+    } catch (error) {
+        alert(`Error inesperado:\n\n${error.message}`);
+        btnGuardar.disabled = false;
+        btnGuardar.innerHTML = textoOriginal;
     }
 }
 

--- a/templates/ver_cotizacion.html
+++ b/templates/ver_cotizacion.html
@@ -641,6 +641,12 @@
                 </svg>
                 Nueva Revisión
             </a>
+            <a href="/formulario?edicion_menor={{ numero_cotizacion | urlencode }}" class="btn" style="background-color: #f59e0b; color: white; border-color: #f59e0b;" title="Corregir typos o texto sin generar nueva revisión">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
+                </svg>
+                Editar
+            </a>
             {% endif %}
             <button onclick="window.print()" class="btn">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
@@ -650,5 +656,27 @@
             </button>
         </div>
     </div>
+<script>
+(function() {
+    try {
+        const obsRaw = {{ cotizacion.get('observaciones', '') | tojson }};
+        if (!obsRaw) return;
+        const obs = JSON.parse(obsRaw);
+        const ediciones = obs && obs.ediciones_menores;
+        if (!ediciones || ediciones.length === 0) return;
+
+        const ultima = ediciones[ediciones.length - 1];
+        const fecha = ultima.timestamp ? new Date(ultima.timestamp).toLocaleString('es-MX') : '';
+        const usuario = ultima.usuario || '';
+
+        const badge = document.createElement('div');
+        badge.style.cssText = 'background:#fef3c7; border:1px solid #f59e0b; border-radius:6px; padding:6px 12px; margin-top:8px; font-size:13px; color:#92400e; display:inline-flex; align-items:center; gap:6px;';
+        badge.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="#f59e0b"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg> Editado el ${fecha}${usuario ? ' por ' + usuario : ''} (${ediciones.length} corrección${ediciones.length > 1 ? 'es' : ''})`;
+
+        const header = document.querySelector('.header');
+        if (header) header.appendChild(badge);
+    } catch(e) {}
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
Permite corregir typos, ortografía y texto sin incrementar la revisión.

Campos editables: atencionA, contacto, descripción de ítems,
tiempoEntrega, entregaEn y comentarios. Todos los campos financieros
y contractuales (precios, moneda, términos de pago, etc.) permanecen
protegidos y requieren una nueva revisión para modificarse.

Cambios:
- supabase_manager.py: método edicion_menor_cotizacion() con whitelist
  estricta y registro de auditoría en campo observaciones
- app.py: endpoint PATCH /api/cotizacion/<numero>/edicion-menor y
  soporte para GET /formulario?edicion_menor=<numero>
- formulario.html: MODO_EDICION_MENOR con banner de advertencia,
  campos deshabilitados, función guardarEdicionMenor() y carga de datos
- ver_cotizacion.html: botón "Editar" ámbar y badge de auditoría
  que muestra fecha/usuario de la última corrección

https://claude.ai/code/session_017TSHB7KxexnZJGn7FqXzHK