### PR TITLE
fix: eliminar campo condiciones de nivel superior en SDK REST INSERT

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -39,7 +39,10 @@
       "Bash(del test_table_format.py)",
       "WebSearch",
       "Bash(del test_descripcion_wrapping.py test_app_functionality.py test_descripcion_wrapping.pdf)",
-      "Bash(npx playwright:*)"
+      "Bash(npx playwright:*)",
+      "mcp__c755b5ce-0113-4c1b-b3d4-e48ef538ab02__list_projects",
+      "mcp__c755b5ce-0113-4c1b-b3d4-e48ef538ab02__execute_sql",
+      "mcp__c755b5ce-0113-4c1b-b3d4-e48ef538ab02__get_logs"
     ],
     "deny": []
   }

--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -626,17 +626,21 @@ class SupabaseManager:
                 raise Exception("SDK de Supabase no disponible")
             
             numero_cotizacion = datos.get('numeroCotizacion')
-            datos_generales = datos.get('datosGenerales', {})
+            datos_generales = dict(datos.get('datosGenerales', {}))
             items = datos.get('items', [])
             condiciones = datos.get('condiciones', {})
             revision = datos.get('revision', 1)
             version = datos.get('version', '1.0.0')
             usuario = datos.get('usuario')
             observaciones = datos.get('observaciones')
-            
+
+            # condiciones se almacena dentro de datos_generales (no existe columna separada en la tabla)
+            if condiciones:
+                datos_generales['condiciones'] = condiciones
+
             print(f"[SDK_REST] Datos extraídos - Número: {numero_cotizacion}, Items: {len(items)}, Revisión: {revision}")
             print(f"[SDK_REST] Condiciones extraídas: {condiciones if condiciones else 'VACÍAS'}")
-            
+
             # Timestamp y fecha
             timestamp = datos.get('timestamp', int(time.time() * 1000))
             fecha_creacion = datos.get('fechaCreacion')
@@ -647,15 +651,14 @@ class SupabaseManager:
                     fecha_creacion = datetime.now().isoformat()
             else:
                 fecha_creacion = datetime.now().isoformat()
-            
+
             print(f"[SDK_REST] Fecha procesada: {fecha_creacion}")
-            
-            # Preparar datos para SDK
+
+            # Preparar datos para SDK (condiciones ya incluida dentro de datos_generales)
             sdk_data = {
                 'numero_cotizacion': numero_cotizacion,
                 'datos_generales': datos_generales,
                 'items': items,
-                'condiciones': condiciones,
                 'revision': revision,
                 'version': version,
                 'fecha_creacion': fecha_creacion,


### PR DESCRIPTION
El campo 'condiciones' era enviado como columna de nivel superior en el
payload de _guardar_cotizacion_sdk(), pero la tabla cotizaciones en Supabase
no tiene esa columna, causando HTTP 400 en cada INSERT vía SDK REST.

La solución embebe condiciones dentro de datos_generales (como ya lo hacía
el método PostgreSQL directo), y _obtener_cotizacion_sdk ya hacía pop() de
ese campo al leer, por lo que la lectura funcionaba correctamente.

Esto causó que el PDF de VALEO-CWS-FM-003-R1-HIDROLAVADORA no se generara:
el INSERT fallaba por 400, el fallback a PostgreSQL guardó la cotización pero
el estado degradado de Supabase Storage después del downtime previo impidió
el upload del PDF.

https://claude.ai/code/session_01KuPiPGQQd28Nyuq9gXGens