### PR TITLE
Add rich text formatting to item description field

### DIFF
--- a/app.py
+++ b/app.py
@@ -427,12 +427,12 @@ def wrap_description_text(text, max_chars_per_line=35):
     """Utility function to wrap long description text for PDF cells"""
     if not text or len(text) <= max_chars_per_line:
         return text
-    
+
     # Split text into words
     words = text.split()
     lines = []
     current_line = ""
-    
+
     for word in words:
         # If adding this word would exceed the limit, start a new line
         if len(current_line + " " + word) > max_chars_per_line and current_line:
@@ -443,13 +443,47 @@ def wrap_description_text(text, max_chars_per_line=35):
                 current_line += " " + word
             else:
                 current_line = word
-    
+
     # Add the last line if it has content
     if current_line:
         lines.append(current_line)
-    
+
     # Join lines with line breaks
     return "<br/>".join(lines)
+
+
+import re as _re
+from html import unescape as _html_unescape
+
+def html_to_reportlab_markup(html_str):
+    """Convert contenteditable HTML to ReportLab Paragraph XML markup."""
+    if not html_str:
+        return ''
+    if '<' not in html_str:
+        return wrap_description_text(html_str)
+
+    def replace_ul(m):
+        lis = _re.findall(r'<li[^>]*>(.*?)</li>', m.group(0), _re.DOTALL | _re.IGNORECASE)
+        rows = []
+        for li in lis:
+            text = _re.sub(r'<[^>]+>', '', li).strip()
+            if text:
+                rows.append(f'• {text}')
+        return '<br/>'.join(rows)
+
+    result = _re.sub(r'<ul[^>]*>.*?</ul>', replace_ul, html_str, flags=_re.DOTALL | _re.IGNORECASE)
+    result = _re.sub(r'<strong[^>]*>', '<b>', result, flags=_re.IGNORECASE)
+    result = _re.sub(r'</strong>', '</b>', result, flags=_re.IGNORECASE)
+    result = _re.sub(r'<em[^>]*>', '<i>', result, flags=_re.IGNORECASE)
+    result = _re.sub(r'</em>', '</i>', result, flags=_re.IGNORECASE)
+    result = _re.sub(r'<br\s*/?>', '<br/>', result, flags=_re.IGNORECASE)
+    result = _re.sub(r'</(p|div)>', '<br/>', result, flags=_re.IGNORECASE)
+    # Remove remaining tags except b, i, u, br
+    result = _re.sub(r'<(?!/?(?:b|i|u|br)(?:\s|/?>))[^>]+>', '', result, flags=_re.IGNORECASE)
+    result = _html_unescape(result)
+    result = _re.sub(r'(<br/>)+', '<br/>', result)
+    result = result.strip().strip('<br/>')
+    return result or ''
 
 def generar_pdf_reportlab(datos_cotizacion):
     """Genera PDF usando ReportLab con formato profesional CWS"""
@@ -772,8 +806,8 @@ def generar_pdf_reportlab(datos_cotizacion):
             
             # Agregar número de item y formatear datos con descripción envuelta
             descripcion_raw = item.get('descripcion', '')
-            descripcion_wrapped = wrap_description_text(descripcion_raw)
-            descripcion_paragraph = Paragraph(descripcion_wrapped, description_style)
+            descripcion_markup = html_to_reportlab_markup(descripcion_raw)
+            descripcion_paragraph = Paragraph(descripcion_markup, description_style)
             
             items_data.append([
                 str(i + 1),  # Número de item

--- a/templates/formato_pdf_cws.html
+++ b/templates/formato_pdf_cws.html
@@ -563,7 +563,7 @@
                         <td><div class="item-number">{{ loop.index }}</div></td>
                         <td>{{ item.cantidad }}</td>
                         <td>{{ item.uom }}</td>
-                        <td class="description">{{ item.descripcion }}</td>
+                        <td class="description">{{ item.descripcion | safe }}</td>
                         <td class="amount">{{ moneda }} {{ item.costoUnidad }}</td>
                         <td class="amount">{{ moneda }} {{ item.total }}</td>
                     </tr>

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -32,6 +32,11 @@
         .btn-loading { opacity: 0.6; cursor: wait !important; }
         .item-block { transition: all 0.2s ease; }
         .item-block:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
+        .descripcion-toolbar button { font-size: 11px; padding: 1px 7px; cursor: pointer; line-height: 1.4; }
+        .descripcion-toolbar button:hover { background: #e5e7eb; }
+        .descripcion-item[contenteditable]:empty::before { content: attr(data-placeholder); color: #9ca3af; pointer-events: none; }
+        .descripcion-item[contenteditable]:focus { outline: none; box-shadow: 0 0 0 2px #3b82f6; }
+        .descripcion-item[contenteditable] ul { list-style: disc; padding-left: 18px; margin: 2px 0; }
         details[open] summary ~ * { animation: slideDown 0.3s ease; }
         @keyframes slideDown { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
         
@@ -851,7 +856,7 @@ function recopilarItems() {
     itemsBlocks.forEach((itemBlock, index) => {
         const item = {
             // Campos principales del item
-            descripcion: itemBlock.querySelector('.descripcion-item')?.value || '',
+            descripcion: itemBlock.querySelector('.descripcion-item')?.innerHTML || '',
             cantidad: itemBlock.querySelector('.cantidad-item')?.value || '',
             uom: itemBlock.querySelector('.uom-item')?.value || '',
             peso: itemBlock.querySelector('[name="peso[]"]')?.value || '',
@@ -1490,7 +1495,7 @@ function capturarEstadoFormulario() {
     itemsBlocks.forEach((itemBlock, index) => {
         const item = {
             // Campos principales del item
-            descripcion: itemBlock.querySelector('.descripcion-item')?.value || '',
+            descripcion: itemBlock.querySelector('.descripcion-item')?.innerHTML || '',
             cantidad: itemBlock.querySelector('.cantidad-item')?.value || '',
             uom: itemBlock.querySelector('.uom-item')?.value || '',
             peso: itemBlock.querySelector('[name="peso[]"]')?.value || '',
@@ -1674,10 +1679,6 @@ function configurarEventListeners() {
                     actualizarTodosLosCalculos();
                 }, 100);
             }
-        }
-        
-        if (e.target.matches('input[placeholder="Ej. Rack Metálico"]')) {
-            setTimeout(() => { actualizarTodosLosCalculos(); }, 100);
         }
         
         // Cálculo en tiempo real para campos de cotizar por peso
@@ -1921,7 +1922,7 @@ function itemEstaVacio(itemElement) {
     // Verificar si un item está vacío (sin información significativa)
 
     // Verificar descripción
-    const descripcion = itemElement.querySelector('.descripcion-item')?.value?.trim() || '';
+    const descripcion = itemElement.querySelector('.descripcion-item')?.textContent?.trim() || '';
     if (descripcion !== '') return false;
 
     // Verificar cantidad
@@ -1996,8 +1997,8 @@ function cargarDatosItem(itemData, index) {
         // Cargar descripción
         const descripcion = item.querySelector('.descripcion-item');
         if (descripcion && itemData.descripcion) {
-            descripcion.value = itemData.descripcion;
-            console.log(`[CARGAR_ITEM] ✅ Descripción cargada: ${itemData.descripcion.substring(0, 30)}...`);
+            descripcion.innerHTML = itemData.descripcion;
+            console.log(`[CARGAR_ITEM] ✅ Descripción cargada: ${String(itemData.descripcion).substring(0, 30)}...`);
         }
 
         // Cargar cantidad
@@ -2609,7 +2610,19 @@ function crearTemplateItem(numero) {
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="md:col-span-2">
                     <label class="block text-sm font-medium mb-1">Descripción:</label>
-                    <input type="text" class="descripcion-item w-full p-2 border rounded text-sm" placeholder="Ej. Rack Metálico">
+                    <div class="descripcion-toolbar flex gap-1 px-1 py-0.5 bg-gray-100 border border-b-0 rounded-t">
+                        <button type="button" class="bg-white border rounded font-bold"
+                                onmousedown="event.preventDefault();document.execCommand('bold',false,null);" title="Negrita">B</button>
+                        <button type="button" class="bg-white border rounded italic"
+                                onmousedown="event.preventDefault();document.execCommand('italic',false,null);" title="Cursiva">I</button>
+                        <button type="button" class="bg-white border rounded underline"
+                                onmousedown="event.preventDefault();document.execCommand('underline',false,null);" title="Subrayado">U</button>
+                        <button type="button" class="bg-white border rounded"
+                                onmousedown="event.preventDefault();document.execCommand('insertUnorderedList',false,null);" title="Lista de viñetas">• Lista</button>
+                    </div>
+                    <div class="descripcion-item w-full p-2 border rounded-b text-sm min-h-[36px] bg-white"
+                         contenteditable="true"
+                         data-placeholder="Ej. Rack Metálico"></div>
                 </div>
                 <div class="grid grid-cols-2 gap-2">
                     <div>

--- a/templates/ver_cotizacion.html
+++ b/templates/ver_cotizacion.html
@@ -284,7 +284,7 @@
 
             {% for item in cotizacion.get('items', []) %}
             <div class="item-container">
-                <h4 class="item-header">Item {{ loop.index }}: {{ item.descripcion or 'Sin descripción' }}</h4>
+                <h4 class="item-header">Item {{ loop.index }}: {{ item.descripcion | safe if item.descripcion else 'Sin descripción' }}</h4>
 
                 <!-- Información del item en formato lista compacto -->
                 <div style="background: #f9fafb; padding: 16px; border-radius: 6px; margin-bottom: 12px;">


### PR DESCRIPTION
Replace plain text input with contenteditable div and a small toolbar
(bold, italic, underline, bullet list) in the quotation form. Descriptions
are now stored as HTML and rendered correctly in the web viewer and PDFs.

- formulario.html: toolbar + contenteditable replacing <input type="text">
- app.py: html_to_reportlab_markup() converts stored HTML for ReportLab PDFs
- ver_cotizacion.html, formato_pdf_cws.html: render description with | safe

https://claude.ai/code/session_015uURXnM93gXg1pEVcgp1YM