### PR TITLE
Fix guardarEdicionMenor() reading .value on contenteditable div

### DIFF
--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -3812,7 +3812,7 @@ async function guardarEdicionMenor() {
             const desc = bloque.querySelector('.descripcion-item');
             const notas = bloque.querySelector('[name="notas[]"]');
             parche.items.push({
-                descripcion: desc ? desc.value.trim() : '',
+                descripcion: desc ? (desc.innerHTML || '').trim() : '',
                 notas: notas ? notas.value.trim() : ''
             });
         });


### PR DESCRIPTION
desc.value on a div returns undefined, causing undefined.trim() TypeError and silently failing the save. Changed to (desc.innerHTML || '').trim() so Edición Menor mode can save formatted descriptions for existing quotations.

https://claude.ai/code/session_015uURXnM93gXg1pEVcgp1YM