### PR TITLE
fix: guardar items aunque no tengan descripcion en recopilarItems()

### DIFF
--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -912,9 +912,10 @@ function recopilarItems() {
             }
         });
 
-        // Solo agregar items con al menos descripción (usar textContent para ignorar markup vacío)
+        // Agregar item si tiene descripción, materiales, u otros materiales
         const descripcionTexto = itemBlock.querySelector('.descripcion-item')?.textContent?.trim() || '';
-        if (descripcionTexto !== '') {
+        const tieneContenido = descripcionTexto !== '' || item.materiales.length > 0 || item.otrosMateriales.length > 0;
+        if (tieneContenido) {
             items.push(item);
         }
     });


### PR DESCRIPTION
El filtro descripcionTexto !== '' descartaba items completos si el contenteditable div estaba vacio. Ahora guarda si tiene descripcion, materiales O otrosMateriales.