### PR TITLE
feat: vista previa PDF con texto IA personalizado

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ DEFAULT_PAGE_SIZE=20
 
 # Configuración de entorno
 FLASK_ENV=production
+
+# Anthropic API (Claude - IA para generación de texto)
+ANTHROPIC_API_KEY=sk-ant-...

--- a/app.py
+++ b/app.py
@@ -3220,6 +3220,139 @@ def listar_cotizaciones():
     
 
 # ============================================
+# GENERACIÓN DE TEXTO IA
+# ============================================
+
+@app.route("/api/generar-texto-ia", methods=["POST"])
+def generar_texto_ia():
+    """
+    Genera texto introductorio personalizado usando Claude AI.
+
+    Body JSON:
+        {
+            "datosGenerales": {...},
+            "items": [...],
+            "condiciones": {...},
+            "revision": "1",
+            "cambiosRevision": "(opcional) descripción de cambios vs rev anterior"
+        }
+
+    Returns:
+        {
+            "success": true,
+            "texto": "texto generado en formato HTML simple"
+        }
+    """
+    try:
+        datos = request.get_json()
+        if not datos:
+            return jsonify({"success": False, "error": "No se recibieron datos"}), 400
+
+        # Intentar usar Claude si está configurado
+        api_key = os.getenv('ANTHROPIC_API_KEY', '').strip()
+        # Solo usar IA si la API key está configurada y no es placeholder
+        if api_key and not api_key.endswith('...') and api_key.startswith('sk-ant-'):
+            import anthropic
+
+            datos_generales = datos.get('datosGenerales', {})
+            items = datos.get('items', [])
+            condiciones = datos.get('condiciones', {})
+            revision = datos.get('revision', '1')
+            cambios = datos.get('cambiosRevision', '')
+
+            cliente = datos_generales.get('cliente', 'Cliente')
+            proyecto = datos_generales.get('proyecto', 'su proyecto')
+            vendedor = datos_generales.get('vendedor', 'CWS Company')
+
+            # Construir resumen de items
+            items_resumen = ""
+            for i, item in enumerate(items[:10]):  # max 10 items para no exceder tokens
+                desc = (item.get('descripcion') or 'Sin descripción')[:100]
+                precio = item.get('total') or item.get('totalItem') or 'N/A'
+                uom = item.get('uom', '')
+                cant = item.get('cantidad', '')
+                items_resumen += f"- Item {i+1}: {desc} | {cant} {uom} | ${precio}\n"
+
+            moneda = condiciones.get('moneda', 'MXN')
+
+            # System prompt
+            system_prompt = (
+                "Eres un cotizador profesional mexicano. Generas textos introductorios "
+                "para PDFs de cotizaciones. Sé conciso, profesional y cálido. "
+                "Escribe en español formal. NO uses markdown. "
+                "Formato: texto plano con saltos de línea simples. "
+                "Máximo 3 párrafos breves."
+            )
+
+            # User prompt
+            user_prompt = f"""Genera el texto introductorio para un PDF de cotización con estos datos:
+
+Cliente: {cliente}
+Proyecto: {proyecto}
+Vendedor: {vendedor}
+Moneda: {moneda}
+Revisión: R{revision}
+
+Resumen de ítems cotizados:
+{items_resumen if items_resumen else 'No se especificaron ítems'}"""
+
+            if cambios and revision != '1':
+                user_prompt += f"\nCambios respecto a revisión anterior:\n{cambios}\nExplica estos cambios de forma profesional.\n"
+
+            user_prompt += "\nEscribe un texto introductorio de 2-3 párrafos que presente la cotización."
+
+            try:
+                client = anthropic.Anthropic(api_key=api_key)
+                message = client.messages.create(
+                    model="claude-sonnet-4-6",
+                    max_tokens=600,
+                    temperature=0.7,
+                    system=system_prompt,
+                    messages=[{"role": "user", "content": user_prompt}]
+                )
+                texto_generado = message.content[0].text
+                print(f"[IA] Texto generado: {len(texto_generado)} caracteres")
+
+                return jsonify({
+                    "success": True,
+                    "texto": texto_generado,
+                    "fuente": "ia"
+                }), 200
+
+            except Exception as ia_error:
+                print(f"[IA] Error llamando a Claude: {str(ia_error)}")
+                # Fallback a texto genérico
+        else:
+            print("[IA] ANTHROPIC_API_KEY no configurada - usando texto genérico")
+
+        # Texto genérico (fallback)
+        datos_generales = datos.get('datosGenerales', {})
+        cliente = datos_generales.get('cliente', 'Cliente')
+        proyecto = datos_generales.get('proyecto', 'su proyecto')
+
+        texto_generico = (
+            f"Estimado {cliente},\n\n"
+            f"CWS Company se complace en presentar esta propuesta económica "
+            f"para {proyecto}. "
+            f"Hemos analizado sus requerimientos y presentamos una solución "
+            f"que equilibra calidad, funcionalidad y costo.\n\n"
+            f"Esperamos haber entendido sus necesidades y permanecemos "
+            f"a la espera de su respuesta."
+        )
+
+        return jsonify({
+            "success": True,
+            "texto": texto_generico,
+            "fuente": "generico"
+        }), 200
+
+    except Exception as e:
+        error_msg = str(e)
+        print(f"[IA] Error en generar-texto-ia: {error_msg}")
+        return jsonify({"success": False, "error": error_msg}), 500
+
+
+# ============================================
 # GENERACIÓN DE PDF
 # ============================================
 
@@ -3237,10 +3370,11 @@ def generar_pdf():
     try:
         datos = request.get_json()
         numero_cotizacion = datos.get('numeroCotizacion')
-        
+        texto_personalizado = datos.get('textoPersonalizado', None)
+
         if not numero_cotizacion:
             return jsonify({"error": "Número de cotización requerido"}), 400
-        
+
         # Buscar la cotización en la base de datos
         resultado = db_manager.obtener_cotizacion(numero_cotizacion)
         
@@ -3305,7 +3439,7 @@ def generar_pdf():
         # Intentar con ReportLab primero (más estable)
         if REPORTLAB_AVAILABLE:
             print("Generando PDF con ReportLab")
-            pdf_data = generar_pdf_reportlab(cotizacion)
+            pdf_data = generar_pdf_reportlab(cotizacion, texto_personalizado=texto_personalizado)
             pdf_buffer = io.BytesIO(pdf_data)
             
         elif WEASYPRINT_AVAILABLE:

--- a/cotizador/pdf_generator.py
+++ b/cotizador/pdf_generator.py
@@ -16,8 +16,14 @@ from cotizador._compat import REPORTLAB_AVAILABLE
 from cotizador.utilities import wrap_description_text
 
 
-def generar_pdf_reportlab(datos_cotizacion):
-    """Genera PDF usando ReportLab con formato profesional CWS"""
+def generar_pdf_reportlab(datos_cotizacion, texto_personalizado=None):
+    """Genera PDF usando ReportLab con formato profesional CWS
+
+    Args:
+        datos_cotizacion: Dict con datos de la cotización
+        texto_personalizado: Texto introductorio personalizado (opcional).
+                            Si es None, se usa el texto genérico.
+    """
     if not REPORTLAB_AVAILABLE:
         raise ImportError("ReportLab no está disponible")
     
@@ -235,10 +241,14 @@ def generar_pdf_reportlab(datos_cotizacion):
         borderWidth=0.5
     )
     
-    intro_text = """Estimado Cliente,<br/>
-    CWS Company se complace en presentar esta propuesta económica para el proyecto solicitado. 
-    Esperamos haber entendido sus requerimientos y permanecemos a la espera de su respuesta."""
-    
+    if texto_personalizado:
+        # Usar texto generado por IA (ya viene con formato HTML de ReportLab)
+        intro_text = texto_personalizado.replace("\n", "<br/>\n")
+    else:
+        intro_text = """Estimado Cliente,<br/>
+        CWS Company se complace en presentar esta propuesta económica para el proyecto solicitado.
+        Esperamos haber entendido sus requerimientos y permanecemos a la espera de su respuesta."""
+
     story.append(Paragraph(intro_text, intro_style))
     story.append(Spacer(1, 8))
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,9 @@ gunicorn==25.1.0
 google-api-python-client==2.191.0
 google-auth==2.48.0
 
+# Claude/Anthropic API (IA para generación de texto personalizado)
+anthropic>=0.84.0
+
 # Cloudinary eliminado - migrado a Supabase Storage
 
 # Scheduler para sincronización automática

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -3934,6 +3934,209 @@ async function guardarEdicionMenor() {
     }
 }
 
+
+<!-- ============================================
+     MODAL: VISTA PREVIA DEL PDF
+     ============================================ -->
+<div id="modal-vista-previa" class="hidden fixed inset-0 z-50 flex items-center justify-center" style="background-color: rgba(0,0,0,0.5);">
+    <div class="bg-white rounded-xl shadow-2xl w-full max-w-3xl mx-4 max-h-[90vh] overflow-y-auto">
+        <!-- Header -->
+        <div class="sticky top-0 bg-gradient-to-r from-blue-600 to-blue-800 text-white px-6 py-4 rounded-t-xl flex items-center justify-between">
+            <h2 class="text-xl font-bold">Vista Previa del PDF</h2>
+            <button onclick="cerrarModalVistaPrevia()" class="text-white hover:text-gray-200 text-2xl leading-none">&times;</button>
+        </div>
+
+        <!-- Body -->
+        <div class="px-6 py-4 space-y-4">
+            <!-- Spinner de carga -->
+            <div id="preview-loading" class="text-center py-8">
+                <div class="inline-block animate-spin rounded-full h-10 w-10 border-4 border-blue-600 border-t-transparent"></div>
+                <p class="mt-3 text-gray-600">Generando texto personalizado...</p>
+            </div>
+
+            <!-- Contenido (inicialmente oculto) -->
+            <div id="preview-content" class="hidden space-y-4">
+                <!-- Texto ejecutivo -->
+                <div>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1">Texto Introductorio:</label>
+                    <textarea id="preview-texto-intro" rows="10"
+                        class="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-y"></textarea>
+                </div>
+
+                <!-- Resumen de items (solo lectura) -->
+                <div>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1">Items de la cotizacion:</label>
+                    <div id="preview-items-resumen" class="bg-gray-50 rounded-lg p-3 text-sm max-h-40 overflow-y-auto"></div>
+                </div>
+
+                <!-- Indicador de fuente -->
+                <div id="preview-fuente" class="text-xs text-gray-400 italic text-right"></div>
+
+                <!-- Acciones -->
+                <div class="flex gap-3 justify-end pt-3 border-t">
+                    <button onclick="cerrarModalVistaPrevia()"
+                        class="px-4 py-2 text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg font-medium transition">
+                        Cancelar
+                    </button>
+                    <button onclick="generarPDFDesdePreview()" id="btn-preview-generar"
+                        class="px-6 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg font-bold transition flex items-center gap-2">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M19,12v7H5v-7H3v7c0,1.1 0.9,2 2,2h14c1.1,0 2-0.9,2-2v-7H19z M13,12.67l2.59-2.58L17,11.5l-5,5l-5-5l1.41-1.41L11,12.67V3h2V12.67z"/></svg>
+                        Generar PDF
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+// ============================================
+// FUNCIONES DEL MODAL VISTA PREVIA PDF
+// ============================================
+
+let numeroCotizacionActual = null;
+
+function cerrarModalVistaPrevia() {
+    document.getElementById('modal-vista-previa').classList.add('hidden');
+    numeroCotizacionActual = null;
+}
+
+async function abrirModalVistaPrevia(numeroCotizacion) {
+    numeroCotizacionActual = numeroCotizacion;
+
+    // Mostrar modal con spinner
+    const modal = document.getElementById('modal-vista-previa');
+    modal.classList.remove('hidden');
+    document.getElementById('preview-loading').style.display = '';
+    document.getElementById('preview-content').classList.add('hidden');
+
+    // Recopilar datos del formulario para el prompt de IA
+    const datosGenerales = recopilarDatosGenerales();
+    const items = recopilarItems();
+    const condiciones = recopilarCondiciones();
+
+    // Detectar si es revision
+    const revision = datosGenerales.revision || '1';
+    let cambiosRevision = '';
+    if (revision !== '1' && estadoInicialFormulario) {
+        // Detectar cambios simples vs estado inicial
+        const itemsActuales = document.querySelectorAll('.item-block').length;
+        const itemsAntes = estadoInicialFormulario.items ? estadoInicialFormulario.items.length : 0;
+        if (itemsActuales !== itemsAntes) {
+            cambiosRevision = 'Se modifico la cantidad de items de ' + itemsAntes + ' a ' + itemsActuales + '.';
+        } else {
+            cambiosRevision = 'Se actualizaron precios y/o materiales.';
+        }
+    }
+
+    try {
+        const resp = await fetch('/api/generar-texto-ia', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                datosGenerales: datosGenerales,
+                items: items,
+                condiciones: condiciones,
+                revision: revision,
+                cambiosRevision: cambiosRevision
+            })
+        });
+
+        const resultado = await resp.json();
+
+        // Ocultar spinner
+        document.getElementById('preview-loading').style.display = 'none';
+        document.getElementById('preview-content').classList.remove('hidden');
+
+        if (resultado.success) {
+            // Poblar textarea con el texto generado
+            document.getElementById('preview-texto-intro').value = resultado.texto;
+
+            // Mostrar fuente (IA o generico)
+            const fuente = resultado.fuente === 'ia' ?
+                'Generado por IA' :
+                'Texto generico (configura ANTHROPIC_API_KEY para personalizar)';
+            document.getElementById('preview-fuente').textContent = fuente;
+        } else {
+            throw new Error(resultado.error || 'Error desconocido');
+        }
+
+    } catch (error) {
+        console.error('[PREVIEW] Error:', error);
+        document.getElementById('preview-loading').style.display = 'none';
+        document.getElementById('preview-content').classList.remove('hidden');
+        document.getElementById('preview-texto-intro').value =
+            'Estimado Cliente,
+
+' +
+            'CWS Company se complace en presentar esta propuesta economica para el proyecto solicitado. ' +
+            'Esperamos haber entendido sus requerimientos y permanecemos a la espera de su respuesta.';
+        document.getElementById('preview-fuente').textContent = 'Texto generico (error: ' + error.message + ')';
+    }
+
+    // Poblar resumen de items
+    let itemsHTML = '<table class="w-full text-xs"><thead><tr class="border-b text-left">';
+    itemsHTML += '<th class="py-1 pr-2">#</th><th class="py-1 pr-2">Descripcion</th><th class="py-1 pr-2">Cant</th><th class="py-1">Total</th></tr></thead><tbody>';
+    items.forEach((item, i) => {
+        const desc = (item.descripcion || 'Sin descripcion').replace(/<[^>]*>/g, '').substring(0, 60);
+        itemsHTML += '<tr class="border-b border-gray-100">';
+        itemsHTML += '<td class="py-1 pr-2">' + (i+1) + '</td>';
+        itemsHTML += '<td class="py-1 pr-2">' + desc + '</td>';
+        itemsHTML += '<td class="py-1 pr-2">' + (item.cantidad || '') + ' ' + (item.uom || '') + '</td>';
+        itemsHTML += '<td class="py-1">$' + (item.totalItem || item.total || '0') + '</td>';
+        itemsHTML += '</tr>';
+    });
+    if (items.length === 0) {
+        itemsHTML += '<tr><td colspan="4" class="py-2 text-gray-400">Sin items</td></tr>';
+    }
+    itemsHTML += '</tbody></table>';
+    document.getElementById('preview-items-resumen').innerHTML = itemsHTML;
+}
+
+async function generarPDFDesdePreview() {
+    if (!numeroCotizacionActual) {
+        alert('Error: No se encontro el numero de cotizacion.');
+        return;
+    }
+
+    const textoPersonalizado = document.getElementById('preview-texto-intro').value.trim();
+    const btnGenerar = document.getElementById('btn-preview-generar');
+    const textoOriginal = btnGenerar.innerHTML;
+
+    try {
+        btnGenerar.disabled = true;
+        btnGenerar.innerHTML = 'Generando PDF...';
+
+        const response = await fetch('/generar_pdf', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                numeroCotizacion: numeroCotizacionActual,
+                textoPersonalizado: textoPersonalizado
+            })
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json();
+            throw new Error(errorData.error || 'Error HTTP ' + response.status);
+        }
+
+        // Cerrar modal
+        cerrarModalVistaPrevia();
+
+        // Abrir PDF en nueva pestana
+        window.open('/pdf/' + numeroCotizacionActual, '_blank');
+
+        alert('PDF generado exitosamente para ' + numeroCotizacionActual + '\n\nEl PDF se ha abierto en una nueva pestana.');
+
+    } catch (error) {
+        alert('Error al generar el PDF:\n\n' + error.message);
+    } finally {
+        btnGenerar.disabled = false;
+        btnGenerar.innerHTML = textoOriginal;
+    }
+}
+
 async function intentarGenerarCotizacion() {
     if (!cotizacionGuardada) {
         alert("Primero debes guardar la cotización antes de generar el PDF.\n\nHaz clic en 'Guardar Cotización' para continuar.");
@@ -3962,66 +4165,9 @@ async function intentarGenerarCotizacion() {
     }
     
     console.log('Numero final para PDF:', numeroCotizacion);
-    
-    const btnGenerar = document.getElementById('btn-generar');
-    const textoOriginal = btnGenerar.innerHTML;
-    
-    try {
-        btnGenerar.disabled = true;
-        btnGenerar.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 6v3l4-4-4-4v3c-4.42 0-8 3.58-8 8 0 1.57.46 3.03 1.24 4.26L6.7 14.8c-.45-.83-.7-1.79-.7-2.8 0-3.31 2.69-6 6-6zm6.76 1.74L17.3 9.2c.44.84.7 1.79.7 2.8 0 3.31-2.69 6-6 6v-3l-4 4 4 4v-3c4.42 0 8-3.58 8-8 0-1.57-.46-3.03-1.24-4.26z"/></svg> Generando PDF...';
-        
-        const response = await fetch('/generar_pdf', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                numeroCotizacion: numeroCotizacion
-            })
-        });
-        
-        if (!response.ok) {
-            const errorData = await response.json();
-            console.error('Error del servidor PDF:', errorData);
-            console.error('Status:', response.status);
-            console.error('StatusText:', response.statusText);
-            
-            let errorMsg = errorData.error || errorData.detalle || `Error HTTP ${response.status}`;
-            if (errorData.mensaje) {
-                errorMsg += '\n' + errorData.mensaje;
-            }
-            throw new Error(errorMsg);
-        }
-        
-        window.open(`/pdf/${numeroCotizacion}`, '_blank');
 
-        alert(`PDF generado exitosamente para la cotización ${numeroCotizacion}\n\nEl PDF se ha abierto en una nueva pestaña.`);
-        
-        btnGenerar.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z"/></svg> PDF Generado';
-        btnGenerar.classList.remove('bg-green-600', 'hover:bg-green-700');
-        btnGenerar.classList.add('bg-blue-600');
-        
-    } catch (error) {
-        let mensajeError = 'Error al generar el PDF:\n\n';
-        
-        if (error.message.includes('WeasyPrint no está instalado')) {
-            mensajeError += 'WeasyPrint no está instalado en el servidor.\n\nPara habilitar la generación de PDF:\n1. Ejecuta: pip install weasyprint\n2. Reinicia el servidor\n3. Consulta INSTRUCCIONES_PDF.md para más detalles';
-        } else if (error.message.includes('weasyprint')) {
-            mensajeError += 'El servidor no tiene WeasyPrint instalado. Contacta al administrador para instalar las dependencias necesarias.';
-        } else if (error.message.includes('no encontrada')) {
-            mensajeError += 'La cotización no fue encontrada en la base de datos. Asegúrate de que esté guardada correctamente.';
-        } else {
-            mensajeError += error.message;
-        }
-        
-        alert(`${mensajeError}\n\nIntenta nuevamente o contacta al soporte técnico.`);
-        
-    } finally {
-        if (btnGenerar.innerHTML.includes('Generando')) {
-            btnGenerar.disabled = false;
-            btnGenerar.innerHTML = textoOriginal;
-        }
-    }
+    // Abrir modal de vista previa con texto IA (reemplaza generacion directa de PDF)
+    abrirModalVistaPrevia(numeroCotizacion);
 }
 </script>
 


### PR DESCRIPTION
- Nuevo endpoint /api/generar-texto-ia genera texto introductorio con Claude
- Fallback a texto generico si ANTHROPIC_API_KEY no esta configurada
- Modal 'Vista Previa' antes de generar PDF con texto editable
- generar_pdf_reportlab() acepta texto_personalizado opcional
- Ruta /generar_pdf recibe y usa textoPersonalizado del frontend
- Agregar anthropic a requirements.txt y ANTHROPIC_API_KEY a .env.example