### PR TITLE
Fix términos y condiciones not showing in PDF

### DIFF
--- a/app.py
+++ b/app.py
@@ -1089,8 +1089,8 @@ def formulario():
             print(f"[FORM_DEBUG] TIPO_CAMBIO RECIBIDO: '{condiciones_recibidas.get('tipoCambio', 'NO_ENCONTRADO')}'")
             print(f"[FORM_DEBUG] TIEMPO_ENTREGA: '{condiciones_recibidas.get('tiempoEntrega', 'NO_ENCONTRADO')}'")
             print(f"[FORM_DEBUG] ENTREGAR_EN: '{condiciones_recibidas.get('entregaEn', 'NO_ENCONTRADO')}'")
-            print(f"[FORM_DEBUG] TERMINOS: '{condiciones_recibidas.get('terminos', 'NO_ENCONTRADO')}'")
-            print(f"[FORM_DEBUG] COMENTARIOS: '{condiciones_recibidas.get('comentarios', 'NO_ENCONTRADO')}'")
+            print(f"[FORM_DEBUG] CONDICIONES_PAGO: '{condiciones_recibidas.get('condicionesPago', 'NO_ENCONTRADO')}'")
+            print(f"[FORM_DEBUG] COMENTARIOS_ADICIONALES: '{condiciones_recibidas.get('comentariosAdicionales', 'NO_ENCONTRADO')}'")
             print(f"[FORM_DEBUG] ======= FIN DIAGNÓSTICO FORMULARIO =======")
             
             # VALIDACIÓN MEJORADA PARA REVISIONES con logging detallado
@@ -2813,8 +2813,8 @@ def generar_pdf():
             'tipoCambio': condiciones.get('tipoCambio', ''),
             'tiempoEntrega': condiciones.get('tiempoEntrega', ''),
             'entregaEn': condiciones.get('entregaEn', ''),
-            'terminos': condiciones.get('terminos', ''),
-            'comentarios': condiciones.get('comentarios', ''),
+            'terminos': condiciones.get('condicionesPago') or condiciones.get('terminos', ''),
+            'comentarios': condiciones.get('comentariosAdicionales') or condiciones.get('comentarios', ''),
             
             # Totales
             'subtotal': f"{subtotal:.2f}",

--- a/cotizador/pdf_generator.py
+++ b/cotizador/pdf_generator.py
@@ -458,8 +458,8 @@ def generar_pdf_reportlab(datos_cotizacion, texto_personalizado=None):
         ('Moneda:', condiciones.get('moneda', 'MXN') if condiciones else 'MXN'),
         ('Tiempo de Entrega:', condiciones.get('tiempoEntrega', '') if condiciones else ''),
         ('Entregar En:', condiciones.get('entregaEn', '') if condiciones else ''),
-        ('Términos de Pago:', condiciones.get('terminos', '') if condiciones else ''),
-        ('Comentarios:', condiciones.get('comentarios', '') if condiciones else '')
+        ('Términos de Pago:', (condiciones.get('condicionesPago') or condiciones.get('terminos', '')) if condiciones else ''),
+        ('Comentarios:', (condiciones.get('comentariosAdicionales') or condiciones.get('comentarios', '')) if condiciones else '')
     ]
     
     # Agregar tipo de cambio si es USD


### PR DESCRIPTION
JavaScript recopilarCondiciones() stores payment terms as 'condicionesPago'
and additional comments as 'comentariosAdicionales', but pdf_generator.py
and the WeasyPrint context in app.py were looking for 'terminos' and
'comentarios', causing the section to always show "A definir" as fallback.

Fix uses both key names for backwards compatibility with any existing data.

https://claude.ai/code/session_01SYdbpewt74yz86eU7D1SD2