### PR TITLE
fix: corregir carga de datos en modo edición menor del formulario

### DIFF
--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -1195,20 +1195,27 @@ class SupabaseManager:
             # Extraer condiciones de datos_generales si existen (compatibilidad)
             datos_generales = row['datos_generales'] or {}
             condiciones = datos_generales.pop('condiciones', {}) if isinstance(datos_generales, dict) else {}
-            
+
+            # Normalizar aliases históricos para que el frontend siempre encuentre los campos
+            if isinstance(condiciones, dict):
+                if 'condicionesPago' in condiciones and 'terminos' not in condiciones:
+                    condiciones['terminos'] = condiciones['condicionesPago']
+                if 'comentariosAdicionales' in condiciones and 'comentarios' not in condiciones:
+                    condiciones['comentarios'] = condiciones['comentariosAdicionales']
+
             cotizacion = {
                 "_id": str(row['id']),
                 "numeroCotizacion": row['numero_cotizacion'],
                 "datosGenerales": datos_generales,
-                "items": row['items'],
+                "items": row['items'] or [],
                 "condiciones": condiciones,
                 "revision": row['revision'],
-                "fechaCreacion": row['fecha_creacion'],
+                "fechaCreacion": str(row['fecha_creacion']) if row['fecha_creacion'] else None,
                 "timestamp": row['timestamp'],
                 "usuario": row['usuario'],
                 "observaciones": row['observaciones']
             }
-            
+
             print(f"[SDK_REST] Cotización obtenida: {numero_cotizacion}")
             return {"encontrado": True, "item": cotizacion}
             
@@ -1239,20 +1246,27 @@ class SupabaseManager:
             # Extraer condiciones de datos_generales si existen
             datos_generales = row['datos_generales'] or {}
             condiciones = datos_generales.pop('condiciones', {}) if isinstance(datos_generales, dict) else {}
-            
+
+            # Normalizar aliases históricos para que el frontend siempre encuentre los campos
+            if isinstance(condiciones, dict):
+                if 'condicionesPago' in condiciones and 'terminos' not in condiciones:
+                    condiciones['terminos'] = condiciones['condicionesPago']
+                if 'comentariosAdicionales' in condiciones and 'comentarios' not in condiciones:
+                    condiciones['comentarios'] = condiciones['comentariosAdicionales']
+
             cotizacion = {
                 "_id": str(row['id']),
                 "numeroCotizacion": row['numero_cotizacion'],
                 "datosGenerales": datos_generales,
-                "items": row['items'],
-                "condiciones": condiciones,  # Extraídas de datos_generales
+                "items": row['items'] or [],
+                "condiciones": condiciones,
                 "revision": row['revision'],
                 "fechaCreacion": row['fecha_creacion'].isoformat() if row['fecha_creacion'] else None,
                 "timestamp": row['timestamp'],
                 "usuario": row['usuario'],
                 "observaciones": row['observaciones']
             }
-            
+
             return {"encontrado": True, "item": cotizacion}
             
         except Exception as e:
@@ -1265,13 +1279,23 @@ class SupabaseManager:
         try:
             data = self._cargar_datos_offline()
             cotizaciones = data.get("cotizaciones", [])
-            
+
             for cot in cotizaciones:
                 if cot.get('numeroCotizacion') == numero_cotizacion:
+                    # Normalizar aliases históricos en condiciones
+                    condiciones = cot.get('condiciones')
+                    if isinstance(condiciones, dict):
+                        if 'condicionesPago' in condiciones and 'terminos' not in condiciones:
+                            condiciones['terminos'] = condiciones['condicionesPago']
+                        if 'comentariosAdicionales' in condiciones and 'comentarios' not in condiciones:
+                            condiciones['comentarios'] = condiciones['comentariosAdicionales']
+                    # Asegurar que items es siempre lista
+                    if cot.get('items') is None:
+                        cot['items'] = []
                     return {"encontrado": True, "item": cot}
-            
+
             return {"encontrado": False, "error": "Cotización no encontrada"}
-            
+
         except Exception as e:
             error_msg = safe_str(e)
             print(f"[OFFLINE] Error obteniendo cotización: {error_msg}")

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -1795,10 +1795,33 @@ function cargarDatosEdicionMenor() {
         const campoHidden = document.querySelector('[name="numeroCotizacionHidden"]');
         if (campoHidden) campoHidden.value = DATOS_EDICION_MENOR.numeroCotizacion || '';
 
-        // Condiciones
-        ['moneda', 'tipoCambio', 'tiempoEntrega', 'entregaEn', 'terminos', 'comentarios'].forEach(campo => {
-            const el = document.querySelector(`[name="${campo}"]`);
-            if (el && cond[campo] !== undefined) el.value = cond[campo];
+        // Condiciones — mapeo explícito para manejar nombres históricos y actuales:
+        // 'condicionesPago' es el nombre almacenado en DB; 'terminos' es el campo HTML
+        // 'comentariosAdicionales' es el nombre almacenado; 'comentarios' es el campo HTML
+        // También se intenta fallback a datosGenerales para cotizaciones antiguas
+        const mapeoCondiciones = {
+            'moneda':                 'moneda',
+            'tipoCambio':             'tipoCambio',
+            'tiempoEntrega':          'tiempoEntrega',
+            'entregaEn':              'entregaEn',
+            'condicionesPago':        'terminos',
+            'terminos':               'terminos',
+            'comentariosAdicionales': 'comentarios',
+            'comentarios':            'comentarios'
+        };
+        Object.entries(mapeoCondiciones).forEach(([claveDB, campoForm]) => {
+            const valor = cond[claveDB] ?? dg[claveDB];
+            if (valor !== undefined && valor !== null && valor !== '') {
+                const el = document.querySelector(`[name="${campoForm}"]`);
+                if (el && el.value === '') el.value = valor;
+            }
+        });
+        console.log('[EDICION_MENOR] Condiciones cargadas:', {
+            moneda: document.querySelector('[name="moneda"]')?.value,
+            tiempoEntrega: document.querySelector('[name="tiempoEntrega"]')?.value,
+            entregaEn: document.querySelector('[name="entregaEn"]')?.value,
+            terminos: document.querySelector('[name="terminos"]')?.value,
+            comentarios: document.querySelector('[name="comentarios"]')?.value
         });
 
         // ── Ítems ──


### PR DESCRIPTION
Al hacer clic en Editar desde el desglose, los campos Términos de Pago
y Comentarios aparecían en blanco porque cargarDatosEdicionMenor buscaba
las claves 'terminos' y 'comentarios', pero la data guardada en DB usa
'condicionesPago' y 'comentariosAdicionales'.

- formulario.html: reemplaza el loop simple de condiciones por un mapeo
  explícito que traduce los nombres históricos (condicionesPago →
  terminos, comentariosAdicionales → comentarios) al campo HTML
  correcto, con fallback a datosGenerales para cotizaciones antiguas
- supabase_manager.py: normaliza los aliases al recuperar cotizaciones
  por los tres métodos (SDK REST, PostgreSQL, JSON offline) para que el
  frontend siempre reciba 'terminos' y 'comentarios'; también garantiza
  que items sea siempre lista y fechaCreacion sea siempre string

https://claude.ai/code/session_01Xd5L4FcKPahT8fvw3gmzMq