### PR TITLE
fix: robustecer carga de datos en flujo Nueva Revisión

### DIFF
--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -1876,12 +1876,6 @@ function cargarDatosPrecargados() {
             'revision': datosGenerales.revision,
             'proyecto': datosGenerales.proyecto,
             'fecha': datosGenerales.fecha,
-            'moneda': datosGenerales.moneda,
-            'tipoCambio': datosGenerales.tipoCambio,
-            'tiempoEntrega': datosGenerales.tiempoEntrega,
-            'entregaEn': datosGenerales.entregaEn,
-            'terminos': datosGenerales.terminos,
-            'comentarios': datosGenerales.comentarios,
             'actualizacionRevision': datosGenerales.actualizacionRevision
         };
         
@@ -1912,8 +1906,8 @@ function cargarDatosPrecargados() {
                 'tipoCambio': condiciones.tipoCambio,
                 'tiempoEntrega': condiciones.tiempoEntrega,
                 'entregaEn': condiciones.entregaEn,
-                'terminos': condiciones.terminos || condiciones.terminosPago,
-                'comentarios': condiciones.comentarios
+                'terminos': condiciones.terminos || condiciones.condicionesPago,
+                'comentarios': condiciones.comentarios || condiciones.comentariosAdicionales || ''
             };
             
             Object.entries(camposCondiciones).forEach(([campo, valor]) => {


### PR DESCRIPTION
## 🔍 Problema

Al revisar el flujo de "Nueva Revisión" (`?revision=NUMERO`) se encontraron tres bugs latentes en `cargarDatosPrecargados()` que, si bien no rompen el flujo principal gracias a la normalización del backend, podían causar pérdida silenciosa de datos en edge cases.

---

## 🐛 Bugs corregidos

### 1. Typo en clave de fallback: `terminosPago` → `condicionesPago`

```diff
- 'terminos': condiciones.terminos || condiciones.terminosPago,
+ 'terminos': condiciones.terminos || condiciones.condicionesPago,
```

La clave histórica real es `condicionesPago` (usada por `recopilarCondiciones()` y normalizada por el backend). La clave `terminosPago` no existe en ningún flujo de guardado ni en la DB. Si la normalización del backend fallaba, el fallback era inútil.

### 2. Sin fallback para `comentarios`

```diff
- 'comentarios': condiciones.comentarios
+ 'comentarios': condiciones.comentarios || condiciones.comentariosAdicionales || ''
```

A diferencia del flujo de edición menor y de drafts, no había fallback a `comentariosAdicionales`. Consistente ahora con el resto del código.

### 3. Campos de condiciones leídos de `datosGenerales` (código muerto)

Se eliminaron 6 campos (`moneda`, `tipoCambio`, `tiempoEntrega`, `entregaEn`, `terminos`, `comentarios`) del primer pase que lee desde `datosGenerales`. El backend extrae estos campos a `condiciones` en `obtener_cotizacion()`, por lo que la primera lectura siempre resultaba `undefined` y era sobrescrita por el segundo pase. Código muerto que confundía el flujo real.

---

## ✅ Lo que YA funciona correctamente (verificado)

| Componente | Estado |
|-----------|--------|
| Normalización del backend (`obtener_cotizacion`) | ✅ |
| `preparar_datos_nueva_revision()` | ✅ |
| Nomenclatura de número (`generar_numero_revision`) | ✅ |
| Modal de justificación (`inicializarModalRevision`) | ✅ |
| PDF (fix PR #60) | ✅ |
| Carga de ítems | ✅ |

## 📋 Archivos

| Archivo | Cambio |
|---------|--------|
| `templates/formulario.html` | Fix typo + add fallback + remove dead code |

🤖 Generated with [Claude Code](https://claude.com/claude-code)