### PR TITLE
fix: reparar botones Editar y Nueva Revisión que no cargaban datos

### DIFF
--- a/app.py
+++ b/app.py
@@ -1711,6 +1711,23 @@ def eliminar_draft(draft_id):
 # EDICIÓN MENOR (sin nueva revisión)
 # ========================================
 
+@app.route("/api/cotizacion/<path:numero_cotizacion>", methods=["GET"])
+def obtener_cotizacion_api(numero_cotizacion):
+    """
+    Devuelve los datos de una cotización en formato JSON.
+    Usado como fallback cuando el template no puede inyectar los datos directamente.
+    """
+    try:
+        from urllib.parse import unquote
+        numero_cotizacion = unquote(numero_cotizacion)
+        resultado = db_manager.obtener_cotizacion(numero_cotizacion)
+        if resultado.get('encontrado'):
+            return jsonify({"success": True, "cotizacion": resultado['item']}), 200
+        else:
+            return jsonify({"success": False, "error": f"Cotización '{numero_cotizacion}' no encontrada"}), 404
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
 @app.route("/api/cotizacion/<path:numero_cotizacion>/edicion-menor", methods=["PATCH"])
 def edicion_menor(numero_cotizacion):
     """

--- a/app.py
+++ b/app.py
@@ -1716,16 +1716,37 @@ def obtener_cotizacion_api(numero_cotizacion):
     """
     Devuelve los datos de una cotización en formato JSON.
     Usado como fallback cuando el template no puede inyectar los datos directamente.
+    Soporta ?preparar_revision=true para el flujo de Nueva Revisión.
     """
     try:
         from urllib.parse import unquote
         numero_cotizacion = unquote(numero_cotizacion)
+        preparar_revision = request.args.get('preparar_revision', '').lower() == 'true'
+
         resultado = db_manager.obtener_cotizacion(numero_cotizacion)
         if resultado.get('encontrado'):
-            return jsonify({"success": True, "cotizacion": resultado['item']}), 200
+            cotizacion = resultado['item']
+            if preparar_revision:
+                # Verificar que sea la revisión más reciente
+                nc = cotizacion.get('numeroCotizacion', '')
+                info_revision = verificar_revision_mas_reciente(nc, db_manager)
+                if not info_revision.get('es_mas_reciente'):
+                    return jsonify({
+                        "success": False,
+                        "error": "No es la revisión más reciente",
+                        "bloqueada": True,
+                        "info": info_revision
+                    }), 409
+                # Preparar datos para nueva revisión
+                cotizacion = preparar_datos_nueva_revision(cotizacion)
+                if cotizacion is None:
+                    return jsonify({"success": False, "error": "Error al preparar revisión"}), 500
+            return jsonify({"success": True, "cotizacion": cotizacion}), 200
         else:
             return jsonify({"success": False, "error": f"Cotización '{numero_cotizacion}' no encontrada"}), 404
     except Exception as e:
+        import traceback
+        traceback.print_exc()
         return jsonify({"success": False, "error": str(e)}), 500
 
 @app.route("/api/cotizacion/<path:numero_cotizacion>/edicion-menor", methods=["PATCH"])
@@ -2830,8 +2851,8 @@ def generar_pdf():
             'tipoCambio': condiciones.get('tipoCambio', ''),
             'tiempoEntrega': condiciones.get('tiempoEntrega', ''),
             'entregaEn': condiciones.get('entregaEn', ''),
-            'terminos': condiciones.get('condicionesPago') or condiciones.get('terminos', ''),
-            'comentarios': condiciones.get('comentariosAdicionales') or condiciones.get('comentarios', ''),
+            'terminos': condiciones.get('terminos') or condiciones.get('condicionesPago', ''),
+            'comentarios': condiciones.get('comentarios') or condiciones.get('comentariosAdicionales', ''),
             
             # Totales
             'subtotal': f"{subtotal:.2f}",

--- a/cotizador/pdf_generator.py
+++ b/cotizador/pdf_generator.py
@@ -458,8 +458,8 @@ def generar_pdf_reportlab(datos_cotizacion, texto_personalizado=None):
         ('Moneda:', condiciones.get('moneda', 'MXN') if condiciones else 'MXN'),
         ('Tiempo de Entrega:', condiciones.get('tiempoEntrega', '') if condiciones else ''),
         ('Entregar En:', condiciones.get('entregaEn', '') if condiciones else ''),
-        ('Términos de Pago:', (condiciones.get('condicionesPago') or condiciones.get('terminos', '')) if condiciones else ''),
-        ('Comentarios:', (condiciones.get('comentariosAdicionales') or condiciones.get('comentarios', '')) if condiciones else '')
+        ('Términos de Pago:', (condiciones.get('terminos') or condiciones.get('condicionesPago', '')) if condiciones else ''),
+        ('Comentarios:', (condiciones.get('comentarios') or condiciones.get('comentariosAdicionales', '')) if condiciones else '')
     ]
     
     # Agregar tipo de cambio si es USD

--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -2089,6 +2089,19 @@ class SupabaseManager:
                             cotizacion['items'][i][campo] = item_patch[campo]
                             campos_modificados.append(f'items[{i}].{campo}')
 
+            # Sincronizar aliases de condiciones para evitar divergencia entre
+            # claves históricas y normalizadas (comentarios <-> comentariosAdicionales)
+            condiciones_actualizadas = cotizacion.get('condiciones') or {}
+            if isinstance(condiciones_actualizadas, dict):
+                if 'comentarios' in condiciones_actualizadas:
+                    condiciones_actualizadas['comentariosAdicionales'] = condiciones_actualizadas['comentarios']
+                elif 'comentariosAdicionales' in condiciones_actualizadas:
+                    condiciones_actualizadas['comentarios'] = condiciones_actualizadas['comentariosAdicionales']
+                if 'terminos' in condiciones_actualizadas:
+                    condiciones_actualizadas['condicionesPago'] = condiciones_actualizadas['terminos']
+                elif 'condicionesPago' in condiciones_actualizadas:
+                    condiciones_actualizadas['terminos'] = condiciones_actualizadas['condicionesPago']
+
             if not campos_modificados:
                 return {'success': False, 'error': 'No se enviaron campos editables'}
 

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -1329,6 +1329,36 @@ document.addEventListener('DOMContentLoaded', function() {
     // Inicializar modal de revisión si es necesario
     inicializarModalRevision();
 
+    // Fallback Nueva Revisión: si DATOS_PRECARGADOS es null pero ?revision=ID está en la URL,
+    // intentar cargar vía API y preparar los datos para nueva revisión
+    if (!DATOS_PRECARGADOS) {
+        const revisionId = new URLSearchParams(window.location.search).get('revision');
+        if (revisionId) {
+            console.warn('[REVISION] DATOS_PRECARGADOS es null — intentando fetch fallback para:', revisionId);
+            fetch('/api/cotizacion/' + encodeURIComponent(revisionId) + '?preparar_revision=true')
+                .then(r => r.json())
+                .then(resultado => {
+                    if (resultado.success && resultado.cotizacion) {
+                        console.log('[REVISION] Datos obtenidos vía API fallback');
+                        window._DATOS_PRECARGADOS_FALLBACK = resultado.cotizacion;
+                        Object.defineProperty(window, 'DATOS_PRECARGADOS', {
+                            get() { return window._DATOS_PRECARGADOS_FALLBACK; },
+                            configurable: true
+                        });
+                        cargarDatosPrecargados();
+                        inicializarModalRevision();
+                    } else {
+                        console.error('[REVISION] API fallback no encontró la cotización:', revisionId, resultado);
+                        alert('No se pudieron cargar los datos de la cotización "' + revisionId + '" para nueva revisión.');
+                    }
+                })
+                .catch(err => {
+                    console.error('[REVISION] Error en fetch fallback (revisión):', err);
+                    alert('Error de conexión al cargar los datos de revisión. Intente recargar la página.');
+                });
+        }
+    }
+
     // Inicializar sistema de auto-guardado de drafts (no aplica en edición menor ni fallback)
     if (!MODO_EDICION_MENOR && !_edicionMenorParam) {
         inicializarSistemaAutoGuardado();
@@ -1828,22 +1858,23 @@ function cargarDatosEdicionMenor() {
         // Condiciones — mapeo explícito para manejar nombres históricos y actuales:
         // 'condicionesPago' es el nombre almacenado en DB; 'terminos' es el campo HTML
         // 'comentariosAdicionales' es el nombre almacenado; 'comentarios' es el campo HTML
-        // También se intenta fallback a datosGenerales para cotizaciones antiguas
+        // IMPORTANTE: las claves normalizadas ('terminos', 'comentarios') van PRIMERO
+        // para que su valor (el más actualizado) tome precedencia sobre los alias históricos.
         const mapeoCondiciones = {
             'moneda':                 'moneda',
             'tipoCambio':             'tipoCambio',
             'tiempoEntrega':          'tiempoEntrega',
             'entregaEn':              'entregaEn',
-            'condicionesPago':        'terminos',
             'terminos':               'terminos',
-            'comentariosAdicionales': 'comentarios',
-            'comentarios':            'comentarios'
+            'condicionesPago':        'terminos',
+            'comentarios':            'comentarios',
+            'comentariosAdicionales': 'comentarios'
         };
         Object.entries(mapeoCondiciones).forEach(([claveDB, campoForm]) => {
-            const valor = cond[claveDB] ?? dg[claveDB];
+            const valor = cond[claveDB];
             if (valor !== undefined && valor !== null && valor !== '') {
                 const el = document.querySelector(`[name="${campoForm}"]`);
-                if (el && el.value === '') el.value = valor;
+                if (el) el.value = valor;
             }
         });
         console.log('[EDICION_MENOR] Condiciones cargadas:', {
@@ -1906,12 +1937,6 @@ function cargarDatosPrecargados() {
             'revision': datosGenerales.revision,
             'proyecto': datosGenerales.proyecto,
             'fecha': datosGenerales.fecha,
-            'moneda': datosGenerales.moneda,
-            'tipoCambio': datosGenerales.tipoCambio,
-            'tiempoEntrega': datosGenerales.tiempoEntrega,
-            'entregaEn': datosGenerales.entregaEn,
-            'terminos': datosGenerales.terminos,
-            'comentarios': datosGenerales.comentarios,
             'actualizacionRevision': datosGenerales.actualizacionRevision
         };
         
@@ -1942,8 +1967,8 @@ function cargarDatosPrecargados() {
                 'tipoCambio': condiciones.tipoCambio,
                 'tiempoEntrega': condiciones.tiempoEntrega,
                 'entregaEn': condiciones.entregaEn,
-                'terminos': condiciones.terminos || condiciones.terminosPago,
-                'comentarios': condiciones.comentarios
+                'terminos': condiciones.terminos || condiciones.condicionesPago,
+                'comentarios': condiciones.comentarios || condiciones.comentariosAdicionales || ''
             };
             
             Object.entries(camposCondiciones).forEach(([campo, valor]) => {

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -1280,27 +1280,57 @@ document.addEventListener('DOMContentLoaded', function() {
     // Cargar datos precargados si existen (revisión) o edición menor
     if (DATOS_PRECARGADOS) {
         cargarDatosPrecargados();
-    } else if (MODO_EDICION_MENOR && DATOS_EDICION_MENOR) {
+    } else if (DATOS_EDICION_MENOR) {
+        // DATOS_EDICION_MENOR vino inyectado correctamente desde el template
         cargarDatosEdicionMenor();
+    } else {
+        // Fallback: si el template no pudo inyectar los datos (error de serialización
+        // o DB fallo al rendir la página), intentar cargar vía API directamente.
+        const urlParams2 = new URLSearchParams(window.location.search);
+        const edicionMenorId = urlParams2.get('edicion_menor');
+        if (edicionMenorId) {
+            console.warn('[EDICION_MENOR] DATOS_EDICION_MENOR es null — intentando fetch fallback para:', edicionMenorId);
+            fetch(`/api/cotizacion/${encodeURIComponent(edicionMenorId)}`)
+                .then(r => r.json())
+                .then(resultado => {
+                    if (resultado.success && resultado.cotizacion) {
+                        console.log('[EDICION_MENOR] Datos obtenidos vía API fallback');
+                        // Inyectar datos y activar modo edición
+                        window._DATOS_EDICION_MENOR_FALLBACK = resultado.cotizacion;
+                        Object.defineProperty(window, 'DATOS_EDICION_MENOR', {
+                            get() { return window._DATOS_EDICION_MENOR_FALLBACK; },
+                            configurable: true
+                        });
+                        // MODO_EDICION_MENOR puede ser false si DB falló; forzarlo
+                        window._MODO_EDICION_MENOR_FALLBACK = true;
+                        Object.defineProperty(window, 'MODO_EDICION_MENOR', {
+                            get() { return window._MODO_EDICION_MENOR_FALLBACK; },
+                            configurable: true
+                        });
+                        cargarDatosEdicionMenor();
+                    } else {
+                        console.error('[EDICION_MENOR] API fallback no encontró la cotización:', edicionMenorId, resultado);
+                        alert('No se pudieron cargar los datos de la cotización "' + edicionMenorId + '".\nVerifique que la cotización existe y vuelva a intentarlo.');
+                    }
+                })
+                .catch(err => {
+                    console.error('[EDICION_MENOR] Error en fetch fallback:', err);
+                    alert('Error de conexión al cargar los datos de edición. Intente recargar la página.');
+                });
+        }
     }
     // En edición menor los ítems se crean dentro de cargarDatosEdicionMenor
-    if (!MODO_EDICION_MENOR) {
+    const _edicionMenorParam = new URLSearchParams(window.location.search).get('edicion_menor');
+    if (!MODO_EDICION_MENOR && !_edicionMenorParam) {
         setTimeout(() => { agregarItem(); }, 500);
     }
     configurarEventListeners();
 
-    // Activar modo edición menor si corresponde (después de que ítems estén cargados)
-    // El timeout se maneja dentro de cargarDatosEdicionMenor
-    if (MODO_EDICION_MENOR && !DATOS_EDICION_MENOR) {
-        // Sin datos no tiene sentido continuar
-        console.warn('[EDICION_MENOR] Sin DATOS_EDICION_MENOR');
-    }
-
     // Inicializar modal de revisión si es necesario
     inicializarModalRevision();
 
-    // Inicializar sistema de auto-guardado de drafts (no aplica en edición menor)
-    if (!MODO_EDICION_MENOR) {
+    // Inicializar sistema de auto-guardado de drafts (no aplica en edición menor ni fallback)
+    if (!MODO_EDICION_MENOR && !_edicionMenorParam) {
         inicializarSistemaAutoGuardado();
     }
 


### PR DESCRIPTION
## 🔍 Causa Raíz

**El PR #59 tenía DOS commits pero solo se mergeó UNO.**

El commit huérfano `8094ef0` agregaba un **API fallback** crítico para cuando el template no puede inyectar los datos (todas las capas DB fallan o devuelven `encontrado:False`). Sin este fallback, el formulario quedaba en blanco sin forma de recuperar los datos.

**Esto explica por qué el bug persistía** incluso después de mergear PR #59.

---

## 🛠️ Correcciones (6 en total)

### 1. Cherry-pick del API fallback para Edición Menor (`8094ef0`)
- **Endpoint**: `GET /api/cotizacion/<numero>` — devuelve la cotización como JSON
- **Frontend**: Si `DATOS_EDICION_MENOR` es `null` pero `?edicion_menor=ID` está en la URL, hace fetch al endpoint, inyecta los datos vía `Object.defineProperty`, y llama a `cargarDatosEdicionMenor()`

### 2. NUEVO: API fallback para Nueva Revisión
- **Endpoint**: Mismo `GET /api/cotizacion/<numero>?preparar_revision=true` que llama a `verificar_revision_mas_reciente()` + `preparar_datos_nueva_revision()`
- **Frontend**: Si `DATOS_PRECARGADOS` es `null` pero `?revision=ID` está en la URL, hace fetch, inyecta los datos, y ejecuta `cargarDatosPrecargados()` + `inicializarModalRevision()`
- Si la revisión está bloqueada, retorna HTTP 409 con la info de bloqueo

### 3. Fix `cargarDatosEdicionMenor()`
- Reordenar mapeo: claves normalizadas (`terminos`, `comentarios`) **PRIMERO**
- Eliminar guardia `el.value === ''` — siempre cargar valor de DB
- Eliminar fallback muerto `?? dg[claveDB]`

### 4. Fix `cargarDatosPrecargados()`
- Corregir typo: `terminosPago` → `condicionesPago`
- Agregar fallback: `comentarios || comentariosAdicionales || ''`
- Eliminar 6 campos de condiciones del primer pase (código muerto)

### 5. Fix PDF: priorizar claves normalizadas
- `app.py`: `terminos` antes que `condicionesPago`, `comentarios` antes que `comentariosAdicionales`
- `pdf_generator.py`: mismo orden

### 6. Fix backend: sincronizar aliases en `edicion_menor_cotizacion()`
- Al guardar `comentarios`, también actualizar `comentariosAdicionales`
- Al guardar `terminos`, también actualizar `condicionesPago`

---

## 📋 Archivos modificados

| Archivo | Cambios |
|---------|---------|
| `app.py` | API endpoint con `?preparar_revision=true` + fix PDF keys |
| `cotizador/pdf_generator.py` | Fix PDF keys priority |
| `supabase_manager.py` | Sync aliases tras parche de edición menor |
| `templates/formulario.html` | API fallback ×2 + fix 2 funciones de carga |

## 🔄 Flujo con fallback



🤖 Generated with [Claude Code](https://claude.com/claude-code)