### PR TITLE
fix: reparar definitivamente botones Editar y Nueva Revisión

### DIFF
--- a/app.py
+++ b/app.py
@@ -536,6 +536,23 @@ def verificar_revision_mas_reciente(numero_cotizacion, db_manager):
             'numero_ultima_revision': numero_cotizacion
         }
 
+def _safe_for_json(obj):
+    """Convierte recursivamente objetos no JSON-serializables (Decimal, datetime, etc.)
+    a tipos nativos de Python que Jinja2's tojson y json.dumps pueden serializar."""
+    from decimal import Decimal
+    import datetime as dt
+    if isinstance(obj, dict):
+        return {k: _safe_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_safe_for_json(v) for v in obj]
+    if isinstance(obj, Decimal):
+        return float(obj)
+    if isinstance(obj, (dt.datetime, dt.date)):
+        return obj.isoformat()
+    if isinstance(obj, bytes):
+        return obj.hex()
+    return obj
+
 def preparar_datos_nueva_revision(cotizacion_original):
     """Prepara los datos de una cotización para crear una nueva revisión"""
     try:
@@ -651,7 +668,7 @@ def preparar_datos_nueva_revision(cotizacion_original):
         datos['datosGenerales']['actualizacionRevision'] = f"Revisión {nueva_revision} basada en cotización original"
         
         print(f"[OK] Datos preparados para nueva revisión: {nuevo_numero}")
-        return datos
+        return _safe_for_json(datos)
         
     except Exception as e:
         print(f"[ERROR] Error preparando nueva revisión: {e}")
@@ -1348,6 +1365,7 @@ def formulario():
         resultado_em = db_manager.obtener_cotizacion(edicion_menor_id)
         if resultado_em.get('encontrado'):
             datos_edicion_menor = resultado_em['item']
+            datos_edicion_menor = _safe_for_json(datos_edicion_menor)
             modo_edicion_menor = True
             print(f"[EDICION_MENOR] Cotización cargada para edición menor: {edicion_menor_id}")
         else:
@@ -1719,11 +1737,15 @@ def obtener_cotizacion_api(numero_cotizacion):
     Soporta ?preparar_revision=true para el flujo de Nueva Revisión.
     """
     try:
+        import time
+        t0 = time.time()
         from urllib.parse import unquote
         numero_cotizacion = unquote(numero_cotizacion)
+        print(f"[API_COTIZACION] Buscando: {numero_cotizacion!r} | preparar_revision={preparar_revision}")
         preparar_revision = request.args.get('preparar_revision', '').lower() == 'true'
 
         resultado = db_manager.obtener_cotizacion(numero_cotizacion)
+        print(f"[API_COTIZACION] Resultado: encontrado={resultado.get('encontrado')} | keys={list(resultado.keys())}")
         if resultado.get('encontrado'):
             cotizacion = resultado['item']
             if preparar_revision:
@@ -1741,11 +1763,14 @@ def obtener_cotizacion_api(numero_cotizacion):
                 cotizacion = preparar_datos_nueva_revision(cotizacion)
                 if cotizacion is None:
                     return jsonify({"success": False, "error": "Error al preparar revisión"}), 500
+            nc_api = cotizacion.get("numeroCotizacion", "?"); rev_api = cotizacion.get("datosGenerales",{}).get("revision","?"); print(f"[API_COTIZACION] [OK] Exito en {time.time()-t0:.3f}s | num={nc_api} | rev={rev_api}")
             return jsonify({"success": True, "cotizacion": cotizacion}), 200
         else:
+            print(f"[API_COTIZACION] ❌ No encontrada: {numero_cotizacion!r} en {time.time()-t0:.3f}s")
             return jsonify({"success": False, "error": f"Cotización '{numero_cotizacion}' no encontrada"}), 404
     except Exception as e:
         import traceback
+        print(f"[API_COTIZACION] [ERROR] {type(e).__name__}: {e} en {time.time()-t0:.3f}s")
         traceback.print_exc()
         return jsonify({"success": False, "error": str(e)}), 500
 
@@ -3005,7 +3030,7 @@ def servir_pdf(numero_cotizacion):
                 return jsonify({"error": f"PDF '{numero_cotizacion}' no encontrado y no hay generador disponible"}), 404
 
             cot_resultado = db_manager.obtener_cotizacion(numero_cotizacion)
-            if not cot_resultado.get("encontrado"):
+            if not cot_resultado.get('encontrado'):
                 return jsonify({"error": f"PDF '{numero_cotizacion}' no encontrado en Storage ni en base de datos"}), 404
 
             cotizacion = cot_resultado["item"]

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -524,14 +524,14 @@
 const LISTA_MATERIALES = {{ materiales | tojson }};
 
 // Datos precargados (para nueva revisión)
-const DATOS_PRECARGADOS = {{ datos_precargados | tojson if datos_precargados else 'null' }};
+let DATOS_PRECARGADOS = {{ datos_precargados | tojson if datos_precargados else 'null' }};
 
 // Información de bloqueo de revisión (si intenta crear revisión desde versión antigua)
 const INFO_BLOQUEO_REVISION = {{ info_bloqueo_revision | tojson if info_bloqueo_revision else 'null' }};
 
 // Modo edición menor (corrección de typos sin nueva revisión)
-const MODO_EDICION_MENOR = {{ modo_edicion_menor | tojson if modo_edicion_menor is defined else 'false' }};
-const DATOS_EDICION_MENOR = {{ datos_edicion_menor | tojson if datos_edicion_menor is defined and datos_edicion_menor else 'null' }};
+let MODO_EDICION_MENOR = {{ modo_edicion_menor | tojson if modo_edicion_menor is defined else 'false' }};
+let DATOS_EDICION_MENOR = {{ datos_edicion_menor | tojson if datos_edicion_menor is defined and datos_edicion_menor else 'null' }};
 
 // Función para generar opciones de materiales
 function generarOpcionesMateriales() {
@@ -1279,6 +1279,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Cargar datos precargados si existen (revisión) o edición menor
     if (DATOS_PRECARGADOS) {
+        inicializarModalRevision();
         cargarDatosPrecargados();
     } else if (DATOS_EDICION_MENOR) {
         // DATOS_EDICION_MENOR vino inyectado correctamente desde el template
@@ -1295,18 +1296,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 .then(resultado => {
                     if (resultado.success && resultado.cotizacion) {
                         console.log('[EDICION_MENOR] Datos obtenidos vía API fallback');
-                        // Inyectar datos y activar modo edición
-                        window._DATOS_EDICION_MENOR_FALLBACK = resultado.cotizacion;
-                        Object.defineProperty(window, 'DATOS_EDICION_MENOR', {
-                            get() { return window._DATOS_EDICION_MENOR_FALLBACK; },
-                            configurable: true
-                        });
-                        // MODO_EDICION_MENOR puede ser false si DB falló; forzarlo
-                        window._MODO_EDICION_MENOR_FALLBACK = true;
-                        Object.defineProperty(window, 'MODO_EDICION_MENOR', {
-                            get() { return window._MODO_EDICION_MENOR_FALLBACK; },
-                            configurable: true
-                        });
+                        // Inyectar datos y activar modo edición (reasignación directa — let permite esto)
+                        DATOS_EDICION_MENOR = resultado.cotizacion;
+                        MODO_EDICION_MENOR = true;
                         cargarDatosEdicionMenor();
                     } else {
                         console.error('[EDICION_MENOR] API fallback no encontró la cotización:', edicionMenorId, resultado);
@@ -1327,7 +1319,9 @@ document.addEventListener('DOMContentLoaded', function() {
     configurarEventListeners();
 
     // Inicializar modal de revisión si es necesario
-    inicializarModalRevision();
+    if (!DATOS_PRECARGADOS) {
+        inicializarModalRevision();
+    }
 
     // Fallback Nueva Revisión: si DATOS_PRECARGADOS es null pero ?revision=ID está en la URL,
     // intentar cargar vía API y preparar los datos para nueva revisión
@@ -1340,13 +1334,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 .then(resultado => {
                     if (resultado.success && resultado.cotizacion) {
                         console.log('[REVISION] Datos obtenidos vía API fallback');
-                        window._DATOS_PRECARGADOS_FALLBACK = resultado.cotizacion;
-                        Object.defineProperty(window, 'DATOS_PRECARGADOS', {
-                            get() { return window._DATOS_PRECARGADOS_FALLBACK; },
-                            configurable: true
-                        });
-                        cargarDatosPrecargados();
+                        DATOS_PRECARGADOS = resultado.cotizacion;
                         inicializarModalRevision();
+                        cargarDatosPrecargados();
                     } else {
                         console.error('[REVISION] API fallback no encontró la cotización:', revisionId, resultado);
                         alert('No se pudieron cargar los datos de la cotización "' + revisionId + '" para nueva revisión.');


### PR DESCRIPTION
CAUSA RAÍZ: El mecanismo de fallback usaba Object.defineProperty(window, ...) para intentar sobreescribir variables declaradas con const. En JavaScript, const crea un binding de scope léxico que NO es una propiedad de window, por lo que Object.defineProperty no tenía efecto. Las funciones cargarDatosEdicionMenor(), cargarDatosPrecargados(), inicializarModalRevision() siempre veían el valor original (null/false) y retornaban sin hacer nada.

CORRECCIONES APLICADAS:

1. FRONTEND — variables mutables (let en vez de const):
   - DATOS_PRECARGADOS, MODO_EDICION_MENOR, DATOS_EDICION_MENOR ahora son let
   - Permite que el fallback API reasigne directamente las variables

2. FRONTEND — fallback con reasignación directa:
   - Editar: DATOS_EDICION_MENOR = resultado.cotizacion; MODO_EDICION_MENOR = true
   - Nueva Revisión: DATOS_PRECARGADOS = resultado.cotizacion
   - Eliminado el Object.defineProperty(window, ...) que no funcionaba

3. FRONTEND — modal de justificación PRIMERO:
   - inicializarModalRevision() ahora se ejecuta antes de cargarDatosPrecargados()
   - El popup de justificación aparece inmediatamente, los datos cargan en segundo plano
   - Llamada standalone envuelta en guardia if (!DATOS_PRECARGADOS)

4. BACKEND — sanitización JSON-safe:
   - Nueva función _safe_for_json() convierte Decimal→float, datetime→ISO string
   - Aplicada en preparar_datos_nueva_revision() y en datos_edicion_menor
   - Previene fallos silenciosos del filtro tojson de Jinja2

5. BACKEND — logging diagnóstico en /api/cotizacion/<numero>:
   - Timing, query, resultado, y errores con trazabilidad completa