### PR TITLE
fix: reparar NameError en API fallback y robustecer triple-layer obte…

### DIFF
--- a/app.py
+++ b/app.py
@@ -1741,8 +1741,8 @@ def obtener_cotizacion_api(numero_cotizacion):
         t0 = time.time()
         from urllib.parse import unquote
         numero_cotizacion = unquote(numero_cotizacion)
-        print(f"[API_COTIZACION] Buscando: {numero_cotizacion!r} | preparar_revision={preparar_revision}")
         preparar_revision = request.args.get('preparar_revision', '').lower() == 'true'
+        print(f"[API_COTIZACION] Buscando: {numero_cotizacion!r} | preparar_revision={preparar_revision}")
 
         resultado = db_manager.obtener_cotizacion(numero_cotizacion)
         print(f"[API_COTIZACION] Resultado: encontrado={resultado.get('encontrado')} | keys={list(resultado.keys())}")

--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -1152,28 +1152,35 @@ class SupabaseManager:
         """
         try:
             # SISTEMA HÍBRIDO TRIPLE LAYER (REORDENADO PARA ESTABILIDAD):
-            # 1. PRIORIDAD: SDK REST de Supabase (funciona independiente de PostgreSQL) 
+            # 1. PRIORIDAD: SDK REST de Supabase (funciona independiente de PostgreSQL)
             if self.supabase_client:
                 try:
                     print("[HIBRIDO_GET] PRIORIDAD 1: Intentando SDK REST para obtener cotización...")
-                    return self._obtener_cotizacion_sdk(numero_cotizacion)
+                    resultado_sdk = self._obtener_cotizacion_sdk(numero_cotizacion)
+                    if resultado_sdk.get('encontrado'):
+                        return resultado_sdk
+                    print("[HIBRIDO_GET] SDK REST no encontró la cotización, intentando PostgreSQL...")
                 except Exception as sdk_error:
                     print(f"[SDK_REST] Error obteniendo cotización: {safe_str(sdk_error)}")
                     print("[SDK_REST] Intentando fallback a PostgreSQL directo...")
-            
+
             # 2. FALLBACK: PostgreSQL directo (solo si está disponible)
             if self.postgresql_disponible:
                 try:
                     print("[HIBRIDO_GET] FALLBACK: Intentando PostgreSQL directo...")
-                    return self._obtener_cotizacion_supabase(numero_cotizacion)
+                    resultado_pg = self._obtener_cotizacion_supabase(numero_cotizacion)
+                    if resultado_pg.get('encontrado'):
+                        return resultado_pg
+                    print("[HIBRIDO_GET] PostgreSQL no encontró la cotización, intentando offline...")
                 except Exception as pg_error:
                     print(f"[POSTGRES] Error obteniendo cotización: {safe_str(pg_error)}")
                     print("[POSTGRES] Activando modo offline para búsqueda...")
                     print("[SDK_REST] Fallback a modo offline")
-            
+
             # 3. Último recurso: JSON offline
+            print("[HIBRIDO_GET] ÚLTIMO RECURSO: Buscando en JSON offline...")
             return self._obtener_cotizacion_offline(numero_cotizacion)
-        
+
         except Exception as e:
             error_msg = safe_str(e)
             print(f"[OBTENER] Error general: {error_msg}")


### PR DESCRIPTION
…ner_cotizacion

- app.py: intercambiar orden de asignación y uso de preparar_revision en /api/cotizacion/<id> (NameError rompía el fallback para ambos flujos)
- supabase_manager.py: obtener_cotizacion() ahora intenta cada capa secuencialmente incluso cuando la capa anterior retorna not-found (antes solo hacía fallback en excepciones, no en not-found limpio)