### PR TITLE
hotfix: mover modal HTML fuera del tag script para eliminar SyntaxError

### DIFF
--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -4018,6 +4018,8 @@ async function guardarEdicionMenor() {
 }
 
 
+</script>
+
 <!-- ============================================
      MODAL: VISTA PREVIA DEL PDF
      ============================================ -->
@@ -4073,6 +4075,7 @@ async function guardarEdicionMenor() {
 </div>
 
 
+<script>
 // ============================================
 // FUNCIONES DEL MODAL VISTA PREVIA PDF
 // ============================================


### PR DESCRIPTION
El modal VISTA PREVIA DEL PDF (HTML) estaba dentro del bloque <script> principal (lineas 4021-4075), causando que el parser JS intentara interpretar <!-- MODAL: VISTA PREVIA DEL PDF como codigo JavaScript, resultando en 'Uncaught SyntaxError: Unexpected identifier PREVIA'.

Ahora el script principal cierra en </script> antes del modal HTML, y las funciones de Vista Previa abren un nuevo bloque <script>.

Esto permite que TODO el JavaScript (DOMContentLoaded, carga de datos, autoguardado) se ejecute correctamente.