### PR TITLE
fix: usar blob directo del PDF y corregir path local en Render

### DIFF
--- a/pdf_manager.py
+++ b/pdf_manager.py
@@ -84,8 +84,11 @@ class PDFManager:
         
         if es_nube:
             # En la nube, usar carpeta local temporal
+            # Usar ruta absoluta basada en la ubicación de este archivo (raíz del proyecto)
+            # en lugar de Path("./") que depende del CWD (puede variar según como inicie el servidor)
             print("Entorno en la nube detectado - usando almacenamiento temporal")
-            fallback = Path("./pdfs_cotizaciones")
+            proyecto_raiz = os.path.dirname(os.path.abspath(__file__))
+            fallback = Path(proyecto_raiz) / "pdfs_cotizaciones"
             fallback.mkdir(parents=True, exist_ok=True)
             print(f"Usando ruta para nube: {fallback.absolute()}")
             return fallback

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -4200,7 +4200,9 @@ async function generarPDFDesdePreview() {
             })
         });
 
-        if (!response.ok) {
+        // Verificar si la respuesta es JSON (error) o PDF (éxito)
+        const contentType = response.headers.get('Content-Type') || '';
+        if (!response.ok || contentType.includes('application/json')) {
             const errorData = await response.json();
             throw new Error(errorData.error || 'Error HTTP ' + response.status);
         }
@@ -4208,11 +4210,18 @@ async function generarPDFDesdePreview() {
         // Guardar numero antes de cerrar (cierre lo borra)
         const numeroParaPDF = numeroCotizacionActual;
 
+        // Usar el PDF directamente desde la respuesta (evita segunda request a /pdf/)
+        const pdfBlob = await response.blob();
+        const pdfUrl = URL.createObjectURL(pdfBlob);
+
         // Cerrar modal
         cerrarModalVistaPrevia();
 
-        // Abrir PDF en nueva pestana
-        window.open('/pdf/' + numeroParaPDF, '_blank');
+        // Abrir PDF en nueva pestaña desde el blob
+        window.open(pdfUrl, '_blank');
+
+        // Liberar el blob URL después de un tiempo
+        setTimeout(() => URL.revokeObjectURL(pdfUrl), 60000);
 
         alert('PDF generado exitosamente para ' + numeroParaPDF + '\n\nEl PDF se ha abierto en una nueva pestana.');
 


### PR DESCRIPTION
- Frontend: usar response.blob() + URL.createObjectURL() en lugar de window.open('/pdf/...') para evitar segunda request que falla en Render por filesystem efímero o path inconsistente.
- pdf_manager.py: usar os.path.dirname(os.path.abspath(__file__)) en lugar de Path('./pdfs_cotizaciones') para que la ruta sea absoluta y no dependa del CWD al momento de iniciar el servidor.