### PR TITLE
feat: persistir texto IA en cotización para no perderlo entre revisiones

### DIFF
--- a/app.py
+++ b/app.py
@@ -571,9 +571,14 @@ def preparar_datos_nueva_revision(cotizacion_original):
         # Actualizar datos generales
         if 'datosGenerales' not in datos:
             datos['datosGenerales'] = {}
-        
+
         datos['datosGenerales']['revision'] = nueva_revision
         datos['datosGenerales']['fecha'] = datetime.datetime.now().strftime('%Y-%m-%d')
+
+        # Preservar texto introductorio de la revisión anterior (si existe)
+        texto_anterior = datos.get('textoIntroductorio') or datos.get('datosGenerales', {}).get('textoIntroductorio', '')
+        if texto_anterior:
+            datos['datosGenerales']['textoIntroductorio'] = texto_anterior
         
         # Generar nuevo número de cotización con revisión usando el sistema automático
         numero_original = datos['datosGenerales'].get('numeroCotizacion', '')
@@ -2999,7 +3004,22 @@ def generar_pdf():
             except Exception as e:
                 print(f"Error en almacenamiento de PDF: {e}")
                 # No fallar la descarga por error de almacenamiento
-        
+
+        # Guardar texto introductorio en la cotización para futuras referencias
+        if texto_personalizado and texto_personalizado.strip():
+            try:
+                if 'datosGenerales' not in cotizacion:
+                    cotizacion['datosGenerales'] = {}
+                cotizacion['datosGenerales']['textoIntroductorio'] = texto_personalizado
+                cotizacion['textoIntroductorio'] = texto_personalizado
+                resultado_texto = db_manager.guardar_cotizacion(cotizacion)
+                if resultado_texto.get('success'):
+                    print(f"Texto introductorio guardado en cotización ({len(texto_personalizado)} chars)")
+                else:
+                    print(f"Error guardando texto introductorio: {resultado_texto.get('error')}")
+            except Exception as e:
+                print(f"Error guardando texto introductorio: {e}")
+
         # Regresar el buffer al inicio para la descarga
         pdf_buffer.seek(0)
         

--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -654,6 +654,11 @@ class SupabaseManager:
 
             print(f"[SDK_REST] Fecha procesada: {fecha_creacion}")
 
+            # Preservar texto introductorio IA (viene en el root del form o en datosGenerales)
+            texto_intro = datos.get('textoIntroductorio') or datos_generales.get('textoIntroductorio', '')
+            if texto_intro:
+                datos_generales['textoIntroductorio'] = texto_intro
+
             # Preparar datos para SDK (condiciones ya incluida dentro de datos_generales)
             sdk_data = {
                 'numero_cotizacion': numero_cotizacion,
@@ -764,7 +769,12 @@ class SupabaseManager:
         # NOTA: Condiciones se guardan dentro de datos_generales temporalmente
         if condiciones:
             datos_generales['condiciones'] = condiciones
-        
+
+        # Preservar texto introductorio IA (del root o de datosGenerales)
+        texto_intro = datos.get('textoIntroductorio') or datos_generales.get('textoIntroductorio', '')
+        if texto_intro:
+            datos_generales['textoIntroductorio'] = texto_intro
+
         def _operacion_guardar():
             """Operación de guardado que será ejecutada con reintentos"""
             cursor = self.pg_connection.cursor()

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -3709,7 +3709,9 @@ async function guardarCotizacion() {
             condiciones: condiciones,
             // Agregar campos de numeración que espera el servidor
             numeroCotizacionHidden: numeroHidden || datosGenerales.numeroCotizacion,
-            numeroCotizacion: datosGenerales.numeroCotizacion
+            numeroCotizacion: datosGenerales.numeroCotizacion,
+            // Preservar texto introductorio IA entre saves
+            textoIntroductorio: textoIntroductorioGuardado || ''
         };
         
         // Debug para Issue #1
@@ -4081,6 +4083,16 @@ async function guardarEdicionMenor() {
 // ============================================
 
 let numeroCotizacionActual = null;
+let textoIntroductorioGuardado = '';
+
+// Cargar texto introductorio guardado desde datos precargados
+if (DATOS_PRECARGADOS) {
+    textoIntroductorioGuardado = (DATOS_PRECARGADOS.datosGenerales || {}).textoIntroductorio
+        || DATOS_PRECARGADOS.textoIntroductorio || '';
+    if (textoIntroductorioGuardado) {
+        console.log('[INIT] Texto introductorio cargado de BD:', textoIntroductorioGuardado.substring(0, 60) + '...');
+    }
+}
 
 function cerrarModalVistaPrevia() {
     document.getElementById('modal-vista-previa').classList.add('hidden');
@@ -4138,6 +4150,11 @@ async function abrirModalVistaPrevia(numeroCotizacion) {
             // Poblar textarea con el texto generado
             document.getElementById('preview-texto-intro').value = resultado.texto;
 
+            // Guardar para usar como fallback en futuras aperturas
+            if (resultado.fuente === 'ia') {
+                textoIntroductorioGuardado = resultado.texto;
+            }
+
             // Mostrar fuente (IA o generico)
             const fuente = resultado.fuente === 'ia' ?
                 'Generado por IA' :
@@ -4151,11 +4168,18 @@ async function abrirModalVistaPrevia(numeroCotizacion) {
         console.error('[PREVIEW] Error:', error);
         document.getElementById('preview-loading').style.display = 'none';
         document.getElementById('preview-content').classList.remove('hidden');
-        document.getElementById('preview-texto-intro').value =
-            'Estimado Cliente,\n\n' +
-            'CWS Company se complace en presentar esta propuesta economica para el proyecto solicitado. ' +
-            'Esperamos haber entendido sus requerimientos y permanecemos a la espera de su respuesta.';
-        document.getElementById('preview-fuente').textContent = 'Texto generico (error: ' + error.message + ')';
+
+        // Usar texto guardado de BD como fallback (en vez del genérico)
+        if (textoIntroductorioGuardado) {
+            document.getElementById('preview-texto-intro').value = textoIntroductorioGuardado;
+            document.getElementById('preview-fuente').textContent = 'Texto guardado (IA no disponible: ' + error.message + ')';
+        } else {
+            document.getElementById('preview-texto-intro').value =
+                'Estimado Cliente,\n\n' +
+                'CWS Company se complace en presentar esta propuesta economica para el proyecto solicitado. ' +
+                'Esperamos haber entendido sus requerimientos y permanecemos a la espera de su respuesta.';
+            document.getElementById('preview-fuente').textContent = 'Texto generico (error: ' + error.message + ')';
+        }
     }
 
     // Poblar resumen de items
@@ -4184,6 +4208,12 @@ async function generarPDFDesdePreview() {
     }
 
     const textoPersonalizado = document.getElementById('preview-texto-intro').value.trim();
+
+    // Guardar para futuras referencias (sobrevive al cierre del modal)
+    if (textoPersonalizado) {
+        textoIntroductorioGuardado = textoPersonalizado;
+    }
+
     const btnGenerar = document.getElementById('btn-preview-generar');
     const textoOriginal = btnGenerar.innerHTML;
 


### PR DESCRIPTION
- Backend: guardar textoIntroductorio en BD al generar PDF (/generar_pdf)
- Backend: preservar textoIntroductorio al crear nueva revisión
- Backend: incluir textoIntroductorio en datos_generales al guardar (SDK + PG)
- Frontend: cargar texto guardado de DATOS_PRECARGADOS al iniciar
- Frontend: usar texto guardado como fallback si IA falla (en vez del genérico)
- Frontend: persistir texto en variable JS que sobrevive al cierre del modal
- Frontend: incluir textoIntroductorio en el payload del save

Fix: el texto IA ya no se pierde al editar y crear nuevas revisiones.