### PR TITLE
fix: backend retorna textoGuardado + frontend cubre edición menor

### DIFF
--- a/app.py
+++ b/app.py
@@ -2750,6 +2750,7 @@ def generar_texto_ia():
 
     Body JSON:
         {
+            "numeroCotizacion": "(opcional) para buscar texto guardado previamente",
             "datosGenerales": {...},
             "items": [...],
             "condiciones": {...},
@@ -2760,13 +2761,33 @@ def generar_texto_ia():
     Returns:
         {
             "success": true,
-            "texto": "texto generado en formato HTML simple"
+            "texto": "texto generado en formato HTML simple",
+            "fuente": "ia" | "generico",
+            "textoGuardado": "texto previamente guardado en BD (opcional, para fallback)"
         }
     """
     try:
         datos = request.get_json()
         if not datos:
             return jsonify({"success": False, "error": "No se recibieron datos"}), 400
+
+        # Buscar texto guardado previamente en la cotización
+        texto_guardado = None
+        numero_cotizacion = datos.get('numeroCotizacion', '').strip()
+        if numero_cotizacion:
+            try:
+                resultado_bd = db_manager.obtener_cotizacion(numero_cotizacion)
+                if resultado_bd.get('encontrado'):
+                    item = resultado_bd['item']
+                    texto_guardado = (
+                        item.get('datosGenerales', {}).get('textoIntroductorio', '') or
+                        item.get('textoIntroductorio', '') or
+                        None
+                    )
+                    if texto_guardado:
+                        print(f"[IA] Texto guardado encontrado en BD ({len(texto_guardado)} chars)")
+            except Exception as e:
+                print(f"[IA] Error buscando texto guardado: {e}")
 
         # Intentar usar Claude si está configurado
         api_key = os.getenv('ANTHROPIC_API_KEY', '').strip()
@@ -2836,7 +2857,8 @@ Resumen de ítems cotizados:
                 return jsonify({
                     "success": True,
                     "texto": texto_generado,
-                    "fuente": "ia"
+                    "fuente": "ia",
+                    "textoGuardado": texto_guardado or texto_generado
                 }), 200
 
             except Exception as ia_error:
@@ -2863,13 +2885,14 @@ Resumen de ítems cotizados:
         return jsonify({
             "success": True,
             "texto": texto_generico,
-            "fuente": "generico"
+            "fuente": "generico",
+            "textoGuardado": texto_guardado or None
         }), 200
 
     except Exception as e:
         error_msg = str(e)
         print(f"[IA] Error en generar-texto-ia: {error_msg}")
-        return jsonify({"success": False, "error": error_msg}), 500
+        return jsonify({"success": False, "error": error_msg, "textoGuardado": None}), 500
 
 
 # ============================================

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -4085,14 +4085,20 @@ async function guardarEdicionMenor() {
 let numeroCotizacionActual = null;
 let textoIntroductorioGuardado = '';
 
-// Cargar texto introductorio guardado desde datos precargados
-if (DATOS_PRECARGADOS) {
-    textoIntroductorioGuardado = (DATOS_PRECARGADOS.datosGenerales || {}).textoIntroductorio
-        || DATOS_PRECARGADOS.textoIntroductorio || '';
-    if (textoIntroductorioGuardado) {
-        console.log('[INIT] Texto introductorio cargado de BD:', textoIntroductorioGuardado.substring(0, 60) + '...');
+// Cargar texto introductorio guardado desde datos precargados (nueva revisión o edición menor)
+(function cargarTextoIntroductorioGuardado() {
+    // Intentar desde DATOS_PRECARGADOS (nueva revisión: ?revision=ID)
+    const fuente = DATOS_PRECARGADOS || DATOS_EDICION_MENOR;
+    if (fuente) {
+        textoIntroductorioGuardado = (fuente.datosGenerales || {}).textoIntroductorio
+            || fuente.textoIntroductorio || '';
+        if (textoIntroductorioGuardado) {
+            console.log('[INIT] Texto introductorio cargado desde ' +
+                (DATOS_PRECARGADOS ? 'DATOS_PRECARGADOS' : 'DATOS_EDICION_MENOR') +
+                ':', textoIntroductorioGuardado.substring(0, 60) + '...');
+        }
     }
-}
+})();
 
 function cerrarModalVistaPrevia() {
     document.getElementById('modal-vista-previa').classList.add('hidden');
@@ -4127,11 +4133,13 @@ async function abrirModalVistaPrevia(numeroCotizacion) {
         }
     }
 
+    let resultado = null;
     try {
         const resp = await fetch('/api/generar-texto-ia', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
+                numeroCotizacion: numeroCotizacion || '',
                 datosGenerales: datosGenerales,
                 items: items,
                 condiciones: condiciones,
@@ -4140,7 +4148,7 @@ async function abrirModalVistaPrevia(numeroCotizacion) {
             })
         });
 
-        const resultado = await resp.json();
+        resultado = await resp.json();
 
         // Ocultar spinner
         document.getElementById('preview-loading').style.display = 'none';
@@ -4153,6 +4161,9 @@ async function abrirModalVistaPrevia(numeroCotizacion) {
             // Guardar para usar como fallback en futuras aperturas
             if (resultado.fuente === 'ia') {
                 textoIntroductorioGuardado = resultado.texto;
+            } else if (resultado.textoGuardado) {
+                // Si cayó en genérico pero hay texto guardado en BD, usarlo
+                textoIntroductorioGuardado = resultado.textoGuardado;
             }
 
             // Mostrar fuente (IA o generico)
@@ -4169,9 +4180,12 @@ async function abrirModalVistaPrevia(numeroCotizacion) {
         document.getElementById('preview-loading').style.display = 'none';
         document.getElementById('preview-content').classList.remove('hidden');
 
-        // Usar texto guardado de BD como fallback (en vez del genérico)
-        if (textoIntroductorioGuardado) {
-            document.getElementById('preview-texto-intro').value = textoIntroductorioGuardado;
+        // Prioridad: 1) texto guardado local, 2) textoGuardado del backend, 3) genérico
+        const textoGuardadoBackend = (typeof resultado !== 'undefined' && resultado && resultado.textoGuardado) || '';
+        const textoFallback = textoIntroductorioGuardado || textoGuardadoBackend;
+
+        if (textoFallback) {
+            document.getElementById('preview-texto-intro').value = textoFallback;
             document.getElementById('preview-fuente').textContent = 'Texto guardado (IA no disponible: ' + error.message + ')';
         } else {
             document.getElementById('preview-texto-intro').value =


### PR DESCRIPTION
- /api/generar-texto-ia: ahora recibe numeroCotizacion y busca texto guardado en BD. Lo retorna como textoGuardado en todas las respuestas.
- Frontend: carga textoIntroductorio también desde DATOS_EDICION_MENOR (antes solo de DATOS_PRECARGADOS - el modo edición menor no se cubría).
- Frontend: envía numeroCotizacion al endpoint IA para que el backend pueda buscar el texto guardado.
- Frontend: usa textoGuardado del backend como fallback adicional.