### PR TITLE
fix: preservar texto IA y condiciones en edición menor

### DIFF
--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -2067,6 +2067,8 @@ class SupabaseManager:
         'datosGenerales': {'atencionA', 'contacto'},
         'condiciones': {'tiempoEntrega', 'entregaEn', 'comentarios'},
         'items': {'descripcion', 'notas'},
+        # textoIntroductorio se permite a nivel raíz (no anidado en datosGenerales)
+        # para preservar el texto IA entre ediciones menores
     }
 
     def validar_campos_edicion_menor(self, parche: dict) -> tuple:
@@ -2112,6 +2114,17 @@ class SupabaseManager:
             # 3. Aplicar parche solo en campos blanqueados
             campos_modificados = []
 
+            # SALVAGUARDA: asegurar que condiciones tenga todos los campos originales.
+            # Si la cotización tiene condiciones en datosGenerales (formato histórico),
+            # mergearlas con las del nivel raíz para no perder moneda, tipoCambio, terminos, etc.
+            dg_cond = cotizacion.get('datosGenerales', {})
+            if isinstance(dg_cond, dict) and 'condiciones' in dg_cond:
+                cond_embebidas = dg_cond.get('condiciones', {}) or {}
+                if isinstance(cond_embebidas, dict):
+                    for k, v in cond_embebidas.items():
+                        if k not in cotizacion.get('condiciones', {}) or not cotizacion['condiciones'].get(k):
+                            cotizacion.setdefault('condiciones', {})[k] = v
+
             dg_patch = parche.get('datosGenerales', {})
             for campo in self.CAMPOS_EDICION_MENOR['datosGenerales']:
                 if campo in dg_patch:
@@ -2147,6 +2160,14 @@ class SupabaseManager:
                     condiciones_actualizadas['comentariosAdicionales'] = condiciones_actualizadas['comentarios']
                 if condiciones_actualizadas.get('comentariosAdicionales') and not condiciones_actualizadas.get('comentarios'):
                     condiciones_actualizadas['comentarios'] = condiciones_actualizadas['comentariosAdicionales']
+
+            # Preservar texto introductorio IA si viene en el parche
+            if 'textoIntroductorio' in parche and parche['textoIntroductorio']:
+                cotizacion['textoIntroductorio'] = parche['textoIntroductorio']
+                if 'datosGenerales' not in cotizacion:
+                    cotizacion['datosGenerales'] = {}
+                cotizacion['datosGenerales']['textoIntroductorio'] = parche['textoIntroductorio']
+                campos_modificados.append('textoIntroductorio')
 
             if not campos_modificados:
                 return {'success': False, 'error': 'No se enviaron campos editables'}

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -3966,6 +3966,11 @@ async function guardarEdicionMenor() {
         const comentarios = document.querySelector('[name="comentarios"]');
         if (comentarios) parche.condiciones.comentarios = comentarios.value.trim();
 
+        // Preservar texto introductorio IA entre ediciones menores
+        if (textoIntroductorioGuardado) {
+            parche.textoIntroductorio = textoIntroductorioGuardado;
+        }
+
         document.querySelectorAll('.item-block').forEach((bloque, i) => {
             const desc = bloque.querySelector('.descripcion-item');
             const notas = bloque.querySelector('[name="notas[]"]');
@@ -4000,11 +4005,16 @@ async function guardarEdicionMenor() {
             btnGuardar.style.backgroundColor = '#10b981';
             btnGuardar.style.borderColor = '#10b981';
             alert(`¡Corrección guardada exitosamente!\n\nNúmero: ${numero}\n\nEl PDF se regenerará con los cambios.`);
-            // Regenerar PDF en segundo plano
+
+            // Regenerar PDF en segundo plano con el texto introductorio guardado
+            const bodyPDF = { numeroCotizacion: numero };
+            if (textoIntroductorioGuardado) {
+                bodyPDF.textoPersonalizado = textoIntroductorioGuardado;
+            }
             fetch('/generar_pdf', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ numeroCotizacion: numero })
+                body: JSON.stringify(bodyPDF)
             }).catch(() => {});
         } else {
             alert(`Error al guardar la corrección:\n\n${resultado.error}`);


### PR DESCRIPTION
Bug 1 - Texto IA se perdía:
- Frontend: incluir textoIntroductorioGuardado en el PATCH y en la regeneración automática del PDF (bodyPDF.textoPersonalizado).
- Backend: aceptar y guardar textoIntroductorio del PATCH en edicion_menor_cotizacion (root + datosGenerales).

Bug 2 - Términos mostraban 'A definir':
- Salvaguarda en edicion_menor_cotizacion: mergear condiciones embebidas en datosGenerales (formato histórico) con las del nivel raíz antes de aplicar el PATCH, para no perder moneda, tipoCambio, terminos, etc.