### PR TITLE
fix: corregir 3 bugs post-implementación del botón Cancelar

### DIFF
--- a/app.py
+++ b/app.py
@@ -3290,7 +3290,7 @@ def ver_desglose(numero_cotizacion):
 
             # Asegurar que exista condiciones (evitar errores de template)
             if not cotizacion.get('condiciones'):
-                cotizacion['condiciones'] = {'moneda': 'MXN'}
+                cotizacion['condiciones'] = {}
                 print(f"[DESGLOSE] Inicializado condiciones con valores por defecto")
 
             # CALCULAR TOTALES para asegurar que se muestren correctamente

--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -629,7 +629,11 @@ class SupabaseManager:
             datos_generales = dict(datos.get('datosGenerales', {}))
             items = datos.get('items', [])
             condiciones = datos.get('condiciones', {})
-            revision = datos.get('revision', 1)
+            revision = datos.get('datosGenerales', {}).get('revision', 1)
+            try:
+                revision = int(revision)
+            except (ValueError, TypeError):
+                revision = 1
             version = datos.get('version', '1.0.0')
             usuario = datos.get('usuario')
             observaciones = datos.get('observaciones')
@@ -748,7 +752,11 @@ class SupabaseManager:
         datos_generales = datos.get('datosGenerales', {})
         items = datos.get('items', [])
         condiciones = datos.get('condiciones', {})
-        revision = datos.get('revision', 1)
+        revision = datos.get('datosGenerales', {}).get('revision', 1)
+        try:
+            revision = int(revision)
+        except (ValueError, TypeError):
+            revision = 1
         version = datos.get('version', '1.0.0')
         usuario = datos.get('usuario')
         observaciones = datos.get('observaciones')
@@ -1235,13 +1243,23 @@ class SupabaseManager:
                 if condiciones.get('comentariosAdicionales') and not condiciones.get('comentarios'):
                     condiciones['comentarios'] = condiciones['comentariosAdicionales']
 
+            # Corregir revision desde numero de cotizacion (fix para datos legacy)
+            revision = row['revision']
+            if revision == 1:
+                import re
+                match = re.search(r'-R(\d+)-', str(row['numero_cotizacion']))
+                if match:
+                    revision_parseada = int(match.group(1))
+                    if revision_parseada > 1:
+                        revision = revision_parseada
+
             cotizacion = {
                 "_id": str(row['id']),
                 "numeroCotizacion": row['numero_cotizacion'],
                 "datosGenerales": datos_generales,
                 "items": row['items'] or [],
                 "condiciones": condiciones,
-                "revision": row['revision'],
+                "revision": revision,
                 "fechaCreacion": str(row['fecha_creacion']) if row['fecha_creacion'] else None,
                 "timestamp": row['timestamp'],
                 "usuario": row['usuario'],
@@ -1292,13 +1310,23 @@ class SupabaseManager:
                 if condiciones.get('comentariosAdicionales') and not condiciones.get('comentarios'):
                     condiciones['comentarios'] = condiciones['comentariosAdicionales']
 
+            # Corregir revision desde numero de cotizacion (fix para datos legacy)
+            revision = row['revision']
+            if revision == 1:
+                import re
+                match = re.search(r'-R(\d+)-', str(row['numero_cotizacion']))
+                if match:
+                    revision_parseada = int(match.group(1))
+                    if revision_parseada > 1:
+                        revision = revision_parseada
+
             cotizacion = {
                 "_id": str(row['id']),
                 "numeroCotizacion": row['numero_cotizacion'],
                 "datosGenerales": datos_generales,
                 "items": row['items'] or [],
                 "condiciones": condiciones,
-                "revision": row['revision'],
+                "revision": revision,
                 "fechaCreacion": row['fecha_creacion'].isoformat() if row['fecha_creacion'] else None,
                 "timestamp": row['timestamp'],
                 "usuario": row['usuario'],
@@ -1327,8 +1355,13 @@ class SupabaseManager:
                     match = (cot.get('numeroCotizacion') == numero_cotizacion)
 
                 if match:
-                    # Normalizar aliases históricos en condiciones
+                    # Normalizar aliases historicos en condiciones
                     condiciones = cot.get('condiciones')
+                    # Si no hay condiciones en nivel raiz, buscar dentro de datosGenerales
+                    if not condiciones:
+                        dg = cot.get('datosGenerales', {})
+                        if isinstance(dg, dict):
+                            condiciones = dg.get('condiciones', {})
                     if isinstance(condiciones, dict):
                         if 'condicionesPago' in condiciones and 'terminos' not in condiciones:
                             condiciones['terminos'] = condiciones['condicionesPago']

--- a/templates/formulario.html
+++ b/templates/formulario.html
@@ -1582,6 +1582,9 @@ function inicializarModalRevision() {
             clearInterval(autoGuardadoTimer);
             autoGuardadoTimer = null;
         }
+        // Prevenir que beforeunload guarde un draft al navegar
+        formModificado = false;
+        cotizacionCompletada = true;
         // Redirigir al inicio (no se guarda nada)
         window.location.href = '/';
     });


### PR DESCRIPTION
## Bugs corregidos

### Bug #1: Cancelar guardaba draft fantasma
Al hacer clic en "Cancelar" en el modal de justificación, el evento `beforeunload` disparaba `sendBeacon` antes de que la redirección surtiera efecto, guardando un draft con datos precargados.

**Fix**: Se agregan `formModificado = false` y `cotizacionCompletada = true` en el handler de Cancelar, bloqueando el `beforeunload` y el `autoGuardarDraftSincrono`.

### Bug #2: Número de revisión siempre mostraba "1"
El save code leía `datos.get('revision', 1)` del nivel raíz del JSON, pero el frontend envía `revision` dentro de `datosGenerales`. Como no existía en la raíz, siempre se guardaba como 1.

**Fix**: 
- Ambos save paths (SDK y PostgreSQL) ahora leen de `datos.get('datosGenerales', {}).get('revision', 1)`
- Fix legacy en read paths: si `revision=1` en DB pero el número contiene `-R#-` con #>1, se usa el valor parseado

### Bug #3: Términos y Condiciones mostraba "N/A"
Dos sub-problemas:
1. El path de lectura offline no extraía `condiciones` de dentro de `datosGenerales`
2. La ruta `/desglose` reemplazaba dicts vacíos con `{'moneda': 'MXN'}`, causando que el template mostrara "N/A" en todos los campos

**Fix**: 
- Offline ahora busca `condiciones` en `datosGenerales` si no está en raíz
- Fallback cambiado a `{}` para que el template maneje los `or 'N/A'` correctamente

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)