### PR TITLE
fix: Bug #3 definitivo — Términos y Condiciones N/A

### DIFF
--- a/app.py
+++ b/app.py
@@ -3290,7 +3290,7 @@ def ver_desglose(numero_cotizacion):
 
             # Asegurar que exista condiciones (evitar errores de template)
             if not cotizacion.get('condiciones'):
-                cotizacion['condiciones'] = {}
+                cotizacion['condiciones'] = {'moneda': 'MXN'}
                 print(f"[DESGLOSE] Inicializado condiciones con valores por defecto")
 
             # CALCULAR TOTALES para asegurar que se muestren correctamente

--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -639,8 +639,7 @@ class SupabaseManager:
             observaciones = datos.get('observaciones')
 
             # condiciones se almacena dentro de datos_generales (no existe columna separada en la tabla)
-            if condiciones:
-                datos_generales['condiciones'] = condiciones
+            datos_generales['condiciones'] = condiciones if condiciones else {}
 
             print(f"[SDK_REST] Datos extraídos - Número: {numero_cotizacion}, Items: {len(items)}, Revisión: {revision}")
             print(f"[SDK_REST] Condiciones extraídas: {condiciones if condiciones else 'VACÍAS'}")
@@ -775,8 +774,7 @@ class SupabaseManager:
                     fecha_dt = datetime.now()
         
         # NOTA: Condiciones se guardan dentro de datos_generales temporalmente
-        if condiciones:
-            datos_generales['condiciones'] = condiciones
+        datos_generales['condiciones'] = condiciones if condiciones else {}
 
         # Preservar texto introductorio IA (del root o de datosGenerales)
         texto_intro = datos.get('textoIntroductorio') or datos_generales.get('textoIntroductorio', '')

--- a/templates/ver_cotizacion.html
+++ b/templates/ver_cotizacion.html
@@ -512,7 +512,7 @@
             </div>
 
             <!-- Información de Moneda y Tipo de Cambio -->
-            {% if cotizacion.condiciones %}
+            {% if cotizacion.condiciones is not none %}
             <div style="margin-top: 20px; padding: 16px; background: #f9fafb; border-radius: 8px; border: 1px solid #e5e7eb;">
                 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 15px;">
                     <div>
@@ -542,7 +542,7 @@
         {% endif %}
 
         <!-- Términos y Condiciones -->
-        {% if cotizacion.condiciones %}
+        {% if cotizacion.condiciones is not none %}
         <div class="section" style="background: #ffffff; border: 2px solid #e5e7eb;">
             <h3 style="display: flex; align-items: center; gap: 10px; color: #374151;">
                 <svg width="22" height="22" viewBox="0 0 24 24" fill="#374151">


### PR DESCRIPTION
## Problema

El fix anterior del Bug #3 (cambiar `{'moneda': 'MXN'}` → `{}` en la ruta /desglose) **empeoró** el comportamiento: cuando condiciones está vacío, la sección completa desaparecía en lugar de mostrarse con "N/A".

## Causa raíz real

1. **`if condiciones:` en el save code** — si condiciones es `{}` (falsy en Python), nunca se guarda en `datos_generales`. Esto rompe la cadena de herencia: todas las revisiones subsecuentes heredan condiciones vacías.
2. **Fallback `{}`** en /desglose — al ser falsy en Jinja2, `{% if cotizacion.condiciones %}` oculta toda la sección.
3. **Template guards** — usan `{% if cotizacion.condiciones %}` que es falsy para dicts vacíos.

## Cambios

| Archivo | Cambio |
|---|---|
| `supabase_manager.py` (2 ubicaciones) | `if condiciones:` → siempre asigna `datos_generales['condiciones']` |
| `app.py` (1 ubicación) | Revertir `{}` → `{'moneda': 'MXN'}` en fallback de /desglose |
| `ver_cotizacion.html` (2 ubicaciones) | `{% if cotizacion.condiciones %}` → `{% if cotizacion.condiciones is not none %}` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)